### PR TITLE
Fix kr_mav_control dependency now that it is open source

### DIFF
--- a/.github/workflows/docker-build-control.yaml
+++ b/.github/workflows/docker-build-control.yaml
@@ -36,15 +36,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        # Clone quadrotor_control into this repo before building
-        name: Checkout quadrotor_control repo
-        uses: actions/checkout@v2
-        with:
-          repository: 'kumarrobotics/quadrotor_control'
-          token: '${{ secrets.AUTONOMY_STACK_QUADROTOR_CONTROL }}'
-          submodules: 'true'
-          path: 'control/pkgs/quadrotor_control'
-      -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -9,11 +9,9 @@ RUN apt update \
 RUN mkdir -p /root/control_ws/src
 WORKDIR /root/control_ws
 COPY control/pkgs src/pkgs
+COPY control/external-repos.yaml src/
 RUN catkin init && catkin config --extend /opt/ros/melodic
-
-# FIXME: We don't run vcs import as quadrotor_control is still a private repo. We have
-# to clone it before building with github actions
-# RUN vcs import --input src/external-repos.yaml src/
+RUN vcs import --input src/external-repos.yaml src/
 RUN catkin build -j2 --no-status -DCMAKE_BUILD_TYPE=Release
 
 COPY control/docker/entrypoint.sh /entrypoint.sh

--- a/control/external-repos.yaml
+++ b/control/external-repos.yaml
@@ -1,5 +1,5 @@
 repositories:
   quadrotor_control:
     type: git
-    url: https://github.com/KumarRobotics/quadrotor_control
-    version: d1785452e104b9be707f00aaf91b941c1715dc8f
+    url: https://github.com/KumarRobotics/kr_mav_control
+    version: fa583db510f534692170b3c885b46d9ab22e664e


### PR DESCRIPTION
We used to clone kr_mav_control using git. Now we can use vcstool because it has been released. 