### PR TITLE
Add Parameters to VoxelMap.msg

### DIFF
--- a/autonomy_core/map_plan/action_planner/src/global_plan_server.cpp
+++ b/autonomy_core/map_plan/action_planner/src/global_plan_server.cpp
@@ -293,7 +293,10 @@ planning_ros_msgs::VoxelMap GlobalPlanServer::clear_map_position(
   planning_ros_msgs::VoxelMap global_map_cleared;
   global_map_cleared = global_map_original;
 
-  int8_t val_free = 0;
+  planning_ros_msgs::VoxelMap voxel_map;
+
+  // Replaced with corresponding parameter value from VoxelMsg.msg
+  int8_t val_free = voxel_map.val_free;
   ROS_WARN_ONCE("Value free is set as %d", val_free);
   double robot_r = 1.0;
   int robot_r_n = std::ceil(robot_r / global_map_cleared.resolution);

--- a/autonomy_core/map_plan/action_planner/src/local_plan_server.cpp
+++ b/autonomy_core/map_plan/action_planner/src/local_plan_server.cpp
@@ -384,7 +384,11 @@ planning_ros_msgs::VoxelMap LocalPlanServer::clear_map_position(
   // maintain both original and cleared maps
   planning_ros_msgs::VoxelMap local_map_cleared;
   local_map_cleared = local_map_original;
-  int8_t val_free = 0;
+
+  planning_ros_msgs::VoxelMap voxel_map;
+  
+  // Replaced with corresponding parameter value from VoxelMsg.msg
+  int8_t val_free = voxel_map.val_free;
   ROS_WARN_ONCE("Value free is set as %d", val_free);
   double robot_r = 1.0;
   int robot_r_n = std::ceil(robot_r / local_map_cleared.resolution);

--- a/autonomy_core/map_plan/jps3d/CMakeLists.txt
+++ b/autonomy_core/map_plan/jps3d/CMakeLists.txt
@@ -3,13 +3,14 @@ project(jps3d)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED
+            COMPONENTS planning_ros_msgs)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 
-catkin_package(INCLUDE_DIRS include LIBRARIES ${PROJECT_NAME})
+catkin_package(INCLUDE_DIRS include LIBRARIES ${PROJECT_NAME} CATKIN_DEPENDS planning_ros_msgs)
 
 add_library(${PROJECT_NAME} src/graph_search.cpp src/jps_planner.cpp
                             src/map_util.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME} PUBLIC include ${catkin_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen Boost::boost)

--- a/autonomy_core/map_plan/jps3d/include/jps/map_util.h
+++ b/autonomy_core/map_plan/jps3d/include/jps/map_util.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "jps/data_type.h"
+#include <planning_ros_msgs/VoxelMap.h>
 
 namespace JPS {
 
@@ -100,6 +101,8 @@ class MapUtil {
   /// Map entity
   Tmap map_;
 
+  planning_ros_msgs::VoxelMap voxel_map;
+
  protected:
   /// Resolution
   decimal_t res_;
@@ -108,11 +111,14 @@ class MapUtil {
   /// Dimension, int type
   Veci<Dim> dim_;
   /// Assume occupied cell has value 100
-  int8_t val_occ = 100;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_occ = voxel_map.val_occ;
   /// Assume free cell has value 0
-  int8_t val_free = 0;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_free = voxel_map.val_free;
   /// Assume unknown cell has value -1
-  int8_t val_unknown = -1;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_unknown = voxel_map.val_unknown;
 };
 
 typedef MapUtil<2> OccMapUtil;

--- a/autonomy_core/map_plan/jps3d/package.xml
+++ b/autonomy_core/map_plan/jps3d/package.xml
@@ -8,6 +8,8 @@
   <license>BSD-3-Clause</license>
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>planning_ros_msgs</depend>
+
   <export>
   </export>
 

--- a/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
+++ b/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
@@ -155,15 +155,21 @@ class VoxelMapper {
   /// Inflated map object, it is a 3D array
   boost::multi_array<int8_t, 3> inflated_map_;
 
+  planning_ros_msgs::VoxelMap voxel_map;
+
   /// Value free
-  int8_t val_free = 0;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_free = voxel_map.val_free;
   /// Value occupied
-  int8_t val_occ = 100;  // DON'T CHANGE THIS! This value is hard-coded in the
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_occ = voxel_map.val_occ;  // DON'T CHANGE THIS! This value is hard-coded in the
                          // planner. (TODO: remove the hard coding in planner)
   /// Value unknown
-  int8_t val_unknown = -1;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_unknown = voxel_map.val_unknown;
   /// Value even
-  int8_t val_even = 50;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_even = voxel_map.val_even;
   /// Value decay (voxels will disappear if unobserved for (val_occ - val_even)
   /// / val_decay times)
   int decay_times_to_empty;
@@ -172,10 +178,12 @@ class VoxelMapper {
   // be careful of overflow (should always be within -128 and 128 range)
   // Add val_add to the voxel whenever a point lies in it. Voxel will be
   // occupied after (val_occ - val_free) / val_add times of such addition.
-  int8_t val_add = 20;  // should always be less than 27 to avoid overflow
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_add = voxel_map.val_add;  // should always be less than 27 to avoid overflow
                         // (should always be within -128 and 128 range)
   /// Default map value
-  int8_t val_default = 0;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_default = voxel_map.val_default;
 };
 
 }  // namespace mapper

--- a/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
+++ b/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
@@ -24,8 +24,11 @@ class VoxelMapper {
    * @param decay_times_to_empty number of times of decay for an occupied voxel
    * to be decayed into empty cell, 0 means no decay
    */
-  VoxelMapper(const Eigen::Vector3d& origin, const Eigen::Vector3d& dim,
-              double res, int8_t val = 0, int decay_times_to_empty = 0);
+  VoxelMapper(const Eigen::Vector3d& origin,
+              const Eigen::Vector3d& dim,
+              double res,
+              int8_t val = 0,
+              int decay_times_to_empty = 0);
 
   /// Set all voxels as unknown
   void setMapUnknown();
@@ -100,8 +103,10 @@ class VoxelMapper {
    *
    * return the new added occupied cells
    */
-  void addCloud(const vec_Vec3d& pts, const Eigen::Affine3d& TF,
-                const vec_Vec3i& ns, bool ray_trace = false,
+  void addCloud(const vec_Vec3d& pts,
+                const Eigen::Affine3d& TF,
+                const vec_Vec3i& ns,
+                bool ray_trace = false,
                 double max_range = 10);
 
   /**
@@ -115,8 +120,12 @@ class VoxelMapper {
    *
    * return the new added occupied cells
    */
-  void addCloud2D(const vec_Vec3d& pts, const Eigen::Affine3d& TF,
-                  const vec_Vec3i& ns, bool ray_trace, double uh, double lh,
+  void addCloud2D(const vec_Vec3d& pts,
+                  const Eigen::Affine3d& TF,
+                  const vec_Vec3i& ns,
+                  bool ray_trace,
+                  double uh,
+                  double lh,
                   double max_range);
 
   /// Free voxels
@@ -162,8 +171,8 @@ class VoxelMapper {
   int8_t val_free = voxel_map.val_free;
   /// Value occupied
   // Now replaced with parameter value from VoxelMap.msg
-  int8_t val_occ = voxel_map.val_occ;  // DON'T CHANGE THIS! This value is hard-coded in the
-                         // planner. (TODO: remove the hard coding in planner)
+  int8_t val_occ = voxel_map.val_occ;
+
   /// Value unknown
   // Now replaced with parameter value from VoxelMap.msg
   int8_t val_unknown = voxel_map.val_unknown;
@@ -176,11 +185,11 @@ class VoxelMapper {
   int8_t val_decay;
 
   // be careful of overflow (should always be within -128 and 128 range)
-  // Add val_add to the voxel whenever a point lies in it. Voxel will be
-  // occupied after (val_occ - val_free) / val_add times of such addition.
+  // Add val_add to the voxel whenever a point lies in it.
   // Now replaced with parameter value from VoxelMap.msg
-  int8_t val_add = voxel_map.val_add;  // should always be less than 27 to avoid overflow
-                        // (should always be within -128 and 128 range)
+  int8_t val_add =
+      voxel_map.val_add;  // should always be less than 27 to avoid overflow
+                          // (should always be within -128 and 128 range)
   /// Default map value
   // Now replaced with parameter value from VoxelMap.msg
   int8_t val_default = voxel_map.val_default;

--- a/autonomy_core/map_plan/mpl/CMakeLists.txt
+++ b/autonomy_core/map_plan/mpl/CMakeLists.txt
@@ -3,13 +3,15 @@ project(motion_primitive_library)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED
+              COMPONENTS planning_ros_msgs)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS planning_ros_msgs
   DEPENDS EIGEN3)
 
 add_library(
@@ -26,5 +28,5 @@ add_library(
   src/planner_base.cpp
   src/state_space.cpp
   src/graph_search.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME} PUBLIC include ${catkin_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen Boost::boost)

--- a/autonomy_core/map_plan/mpl/include/mpl_collision/map_util.h
+++ b/autonomy_core/map_plan/mpl/include/mpl_collision/map_util.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mpl_basis/data_type.h"
+#include <planning_ros_msgs/VoxelMap.h>
 
 namespace MPL {
 
@@ -75,6 +76,8 @@ class MapUtil {
   /// Get unknown voxels for 3D
   vec_Vecf<Dim> getUnknownCloud();
 
+  planning_ros_msgs::VoxelMap voxel_map;
+
  protected:
   /// Map resolution
   decimal_t res_;
@@ -86,11 +89,14 @@ class MapUtil {
   Tmap map_;
 
   /// Assume occupied cell has value 100
-  int8_t val_occ = 100;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_occ = voxel_map.val_occ;
   /// Assume free cell has value 0
-  int8_t val_free = 0;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_free = voxel_map.val_free;
   /// Assume unknown cell has value -1
-  int8_t val_unknown = -1;
+  // Now replaced with parameter value from VoxelMap.msg
+  int8_t val_unknown = voxel_map.val_unknown;
 };
 
 typedef MapUtil<2> OccMapUtil;

--- a/autonomy_core/map_plan/mpl/package.xml
+++ b/autonomy_core/map_plan/mpl/package.xml
@@ -8,6 +8,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>planning_ros_msgs</depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
   </export>

--- a/autonomy_core/map_plan/planning_ros_msgs/msg/VoxelMap.msg
+++ b/autonomy_core/map_plan/planning_ros_msgs/msg/VoxelMap.msg
@@ -12,9 +12,11 @@ geometry_msgs/Point dim
 int8[] data
 
 # Parameters for the occupancy condition of the current map
+# Be careful of overflow (should always be within -128 and 128 range)
 int8 val_occ = 100
 int8 val_even = 50
 int8 val_unknown = -1
 int8 val_free = 0
+# Add val_add to the voxel whenever a point lies in it
 int8 val_add = 20
 int8 val_default = 0

--- a/autonomy_core/map_plan/planning_ros_msgs/msg/VoxelMap.msg
+++ b/autonomy_core/map_plan/planning_ros_msgs/msg/VoxelMap.msg
@@ -10,3 +10,11 @@ geometry_msgs/Point dim
 
 # Subscript (xi, yi, zi) indices probability data[xi + dim.x * yi + zi * dim.x * dim.y]
 int8[] data
+
+# Parameters for the occupancy condition of the current map
+int8 val_occ = 100
+int8 val_even = 50
+int8 val_unknown = -1
+int8 val_free = 0
+int8 val_add = 20
+int8 val_default = 0


### PR DESCRIPTION
Added the variables, `val_occ, val_even, val_unknown, val_free, val_add and val_default` to `VoxelMap.msg` file with their default value. Subsequently replaced hard-codings of all these variables in `map_utils.h` files of the `mpl `and `jps3d` packages, `voxel_mapper.h` file from `mapper` package and `global_plan_server.cpp` and `local_plan_server.cpp` files from `action_planner` package