### PR TITLE
Map data type

### DIFF
--- a/autonomy_core/map_plan/mapper/CMakeLists.txt
+++ b/autonomy_core/map_plan/mapper/CMakeLists.txt
@@ -33,4 +33,10 @@ enable_testing()
 catkin_add_gtest(test_voxel_mapper test/test_voxel_mapper.cpp)
 target_link_libraries(test_voxel_mapper ${catkin_LIBRARIES} ${PROJECT_NAME})
 
+#----------------------------------------------------------------------------------
+# Add microbenchmarking with Google Benchmark
+find_package(benchmark REQUIRED)
+add_executable(benchmarking test/benchmark_voxel_mapper.cpp)
+target_link_libraries(benchmarking benchmark::benchmark ${PROJECT_NAME})
+
 

--- a/autonomy_core/map_plan/mapper/CMakeLists.txt
+++ b/autonomy_core/map_plan/mapper/CMakeLists.txt
@@ -30,18 +30,7 @@ target_link_libraries(local_global_mapper PUBLIC ${PROJECT_NAME} Boost::timer)
 # Add testing with GoogleTest
 enable_testing()
 
-add_executable(
-    test_voxel_mapper
-    src/test_voxel_mapper.cpp
-)
-
-target_link_libraries(
-    test_voxel_mapper PUBLIC
-    ${PROJECT_NAME}
-    gtest_main
-)
-
-include(GoogleTest)
-gtest_discover_tests(test_voxel_mapper)
+catkin_add_gtest(test_voxel_mapper test/test_voxel_mapper.cpp)
+target_link_libraries(test_voxel_mapper ${catkin_LIBRARIES} ${PROJECT_NAME})
 
 

--- a/autonomy_core/map_plan/mapper/CMakeLists.txt
+++ b/autonomy_core/map_plan/mapper/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(local_global_mapper PUBLIC ${PROJECT_NAME} Boost::timer)
 
 #----------------------------------------------------------------------------------
 # Add testing with GoogleTest
+
+# To run test:
+#   catkin test mapper
 enable_testing()
 
 catkin_add_gtest(test_voxel_mapper test/test_voxel_mapper.cpp)
@@ -35,7 +38,24 @@ target_link_libraries(test_voxel_mapper ${catkin_LIBRARIES} ${PROJECT_NAME})
 
 #----------------------------------------------------------------------------------
 # Add microbenchmarking with Google Benchmark
-find_package(benchmark REQUIRED)
+
+# To run benchmark:
+#   rosrun mapper benchmarking
+# if you want to save the results to a file: 
+#   rosrun mapper benchmarking --benchmark_out=file_name.json
+# if you want to compare two benchmark files, use the compare.py script located
+# in the build directory under mapper/_deps/benchmark-src/tools/ (you will need
+# to have pandas installed). Also changed the shebang to use python3
+# e.g. from the catkin root directory run:
+#   ./build/mapper/_deps/benchmark-src/tools/compare.py benchmarks file1.json file2.json 
+
+include(FetchContent)
+FetchContent_Declare(
+    benchmark
+    URL https://github.com/google/benchmark/archive/b7afda2cd2d81230737caa1073e160b6406798d7.zip
+)
+FetchContent_MakeAvailable(benchmark)
+
 add_executable(benchmarking test/benchmark_voxel_mapper.cpp)
 target_link_libraries(benchmarking benchmark::benchmark ${PROJECT_NAME})
 

--- a/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
+++ b/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
@@ -6,6 +6,7 @@
 #include <boost/multi_array.hpp>
 #include <gtest/gtest_prod.h>
 #include <mpl_collision/map_util.h>
+#include <vector>
 
 namespace mapper {
 

--- a/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
+++ b/autonomy_core/map_plan/mapper/include/mapper/voxel_mapper.h
@@ -19,7 +19,6 @@ class VoxelMapper {
   // access private methods and members
   friend class VoxelMapperTest;
   FRIEND_TEST(VoxelMapperTest, TestAllocateRelocate);
-  FRIEND_TEST(VoxelMapperTest, TestDecayLocalCloud);
 
  public:
   /**
@@ -37,6 +36,9 @@ class VoxelMapper {
               int8_t val = 0,
               int decay_times_to_empty = 0);
 
+  /// set the map with some predefined values
+  void setMap(const Eigen::Vector3d &ori, const Eigen::Vector3i &dim,
+              const std::vector<signed char> &map, double res);
   /// Set all voxels as unknown
   void setMapUnknown();
   /// Set all voxels as free

--- a/autonomy_core/map_plan/mapper/src/voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/src/voxel_mapper.cpp
@@ -17,7 +17,8 @@ VoxelMapper::VoxelMapper(const Eigen::Vector3d& origin,
   allocate(origin, dim);
   if (decay_times_to_empty >= 1) {
     val_decay_ =
-        std::ceil((float)(val_occ_ - val_even_) / (float)decay_times_to_empty);
+        std::ceil(static_cast<float>(val_occ_ - val_even_)
+        / static_cast<float>(decay_times_to_empty));
   } else {
     val_decay_ = 0;  // no decay
   }

--- a/autonomy_core/map_plan/mapper/test/benchmark_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/benchmark_voxel_mapper.cpp
@@ -1,0 +1,202 @@
+#include <benchmark/benchmark.h>
+#include "mapper/voxel_mapper.h"
+
+/**
+ * @brief Arguments represent the x-dim, y-dim, and z-dim size respectively. The
+ * fourth argument is the resolution multiplied by 100 because arguments are
+ * signed long.
+ */
+static void BM_GetMap(benchmark::State& state) {
+  int x_dim = state.range(0);
+  int y_dim = state.range(1);
+  int z_dim = state.range(2);
+  int x_origin = - x_dim / 2;
+  int y_origin = - y_dim / 2;
+  int z_origin = - z_dim / 2;
+  double resolution = static_cast<double>(state.range(3)) / 100.0;
+  int8_t val_default = 0;
+  int decay_times = 30;
+  Eigen::Vector3d origin(x_origin, y_origin, z_origin);
+  Eigen::Vector3d dimensions(x_dim, y_dim, z_dim);
+  mapper::VoxelMapper test_mapper(origin, dimensions,
+                                  resolution, val_default,
+                                  decay_times);
+
+  for (auto _ : state) {
+    test_mapper.getMap();
+  }
+}
+
+BENCHMARK(BM_GetMap)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
+
+/**
+ * @brief Arguments represent the x-dim, y-dim, and z-dim size respectively. The
+ * fourth argument is the resolution multiplied by 100 because arguments are
+ * signed long.
+ */
+static void BM_DecayLocalCloud(benchmark::State& state) {
+  int x_dim = state.range(0);
+  int y_dim = state.range(1);
+  int z_dim = state.range(2);
+  int x_origin = - x_dim / 2;
+  int y_origin = - y_dim / 2;
+  int z_origin = - z_dim / 2;
+  double resolution = static_cast<double>(state.range(3)) / 100.0;
+  int8_t val_default = 0;
+  int decay_times = 30;
+  Eigen::Vector3d origin(x_origin, y_origin, z_origin);
+  Eigen::Vector3d dimensions(x_dim, y_dim, z_dim);
+  mapper::VoxelMapper test_mapper(origin, dimensions,
+                                  resolution, val_default,
+                                  decay_times);
+
+  Eigen::Vector3d position(0, 0, 0);
+  double max_range = 9.8;
+
+  for (auto _ : state) {
+    test_mapper.decayLocalCloud(position, max_range);
+  }
+}
+
+BENCHMARK(BM_DecayLocalCloud)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
+
+/**
+ * @brief Arguments represent the x-dim, y-dim, and z-dim size respectively. The
+ * fourth argument is the resolution multiplied by 100 because arguments are
+ * signed long.
+ */
+static void BM_AddCloud(benchmark::State& state) {
+  int x_dim = state.range(0);
+  int y_dim = state.range(1);
+  int z_dim = state.range(2);
+  int x_origin = - x_dim / 2;
+  int y_origin = - y_dim / 2;
+  int z_origin = - z_dim / 2;
+  double resolution = static_cast<double>(state.range(3)) / 100.0;
+  int8_t val_default = 0;
+  int decay_times = 30;
+  Eigen::Vector3d origin(x_origin, y_origin, z_origin);
+  Eigen::Vector3d dimensions(x_dim, y_dim, z_dim);
+  mapper::VoxelMapper test_mapper(origin, dimensions,
+                                  resolution, val_default,
+                                  decay_times);
+
+  // We will consider that the lidar is at position (-10, -5, -1) in the map
+  // frame of reference
+  Eigen::Vector3d lidar_pos(-10, -5, -1);
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(-10, -5, -1) *
+                                Eigen::AngleAxisd(0,
+                                                  Eigen::Vector3d(0, 0, 0));
+  double max_range = 30.0;
+  mapper::vec_Vec3d lidar_points;
+
+  // Add 3 points for all voxels in the range -30 to 30 in all 3 axes. Some
+  // will be discarded and only a sperical shape of voxels around
+  // (-10, -5, -1) should be marked as occupied
+  for (int x = 0; x <= 120; x++) {
+      for (int y = 0; y <= 120; y++) {
+          for (int z = 0; z <= 120; z++) {
+              double real_x = -30 + x * 0.5;
+              double real_y = -30 + y * 0.5;
+              double real_z = -30 + z * 0.5;
+              Eigen::Vector3d point(real_x, real_y, real_z);
+              lidar_points.push_back(point);
+          }
+      }
+  }
+
+  // Current neighboring voxels are just +-1 in x and y directions
+  mapper::vec_Vec3i neighbors;
+  neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
+  neighbors.push_back(Eigen::Vector3i(1, 0, 0));
+  neighbors.push_back(Eigen::Vector3i(0, -1, 0));
+  neighbors.push_back(Eigen::Vector3i(0, 1, 0));
+
+  for (auto _ : state) {
+    test_mapper.addCloud(lidar_points, t_map_lidar, neighbors, false,
+                         max_range);
+  }
+}
+
+BENCHMARK(BM_AddCloud)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
+
+/**
+ * @brief Arguments represent the x-dim, y-dim, and z-dim size respectively. The
+ * fourth argument is the resolution multiplied by 100 because arguments are
+ * signed long.
+ */
+static void BM_GetInflatedLocalMap(benchmark::State& state) {
+  int x_dim = state.range(0);
+  int y_dim = state.range(1);
+  int z_dim = state.range(2);
+  int x_origin = - x_dim / 2;
+  int y_origin = - y_dim / 2;
+  int z_origin = - z_dim / 2;
+  double resolution = static_cast<double>(state.range(3)) / 100.0;
+  int8_t val_default = 0;
+  int decay_times = 30;
+  Eigen::Vector3d origin(x_origin, y_origin, z_origin);
+  Eigen::Vector3d dimensions(x_dim, y_dim, z_dim);
+  mapper::VoxelMapper test_mapper(origin, dimensions,
+                                  resolution, val_default,
+                                  decay_times);
+
+  Eigen::Vector3d local_origin(75, 25, 2.5);
+  Eigen::Vector3d local_dimensions(100, 100, 10);
+
+  for (auto _ : state) {
+    test_mapper.getInflatedLocalMap(local_origin, local_dimensions);
+  }
+}
+
+BENCHMARK(BM_GetInflatedLocalMap)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
+
+// class VoxelMapperBenchmark : public benchmark::Fixture {
+//  public:
+//   void SetUp(const ::benchmark::State& state) {
+//     int x_origin_ = -100;
+//     int y_origin_ = -100;
+//     int z_origin_ = -5;
+//     int x_dim_ = 200;
+//     int y_dim_ = 200;
+//     int z_dim_ = 10;
+//     double resolution_ = 0.5;
+//     int8_t val_default_ = 0;
+//     int decay_times_ = 30;
+//     Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
+//     Eigen::Vector3d dimensions(x_dim_, y_dim_, z_dim_);
+//     p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions,
+//                                         resolution_, val_default_,
+//                                         decay_times_));
+//   }
+
+//   std::unique_ptr<mapper::VoxelMapper> p_test_mapper_;  
+
+// };
+
+// BENCHMARK_DEFINE_F(VoxelMapperBenchmark, GetMapTest)(benchmark::State& st) {
+//   for (auto _ : st) {
+//     p_test_mapper_->getMap();
+//   }
+// }
+
+// BENCHMARK_REGISTER_F(VoxelMapperBenchmark, GetMapTest);
+
+
+BENCHMARK_MAIN();

--- a/autonomy_core/map_plan/mapper/test/benchmark_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/benchmark_voxel_mapper.cpp
@@ -6,7 +6,7 @@
  * fourth argument is the resolution multiplied by 100 because arguments are
  * signed long.
  */
-static void BM_GetMap(benchmark::State& state) {
+static void BM_GetInflatedMap(benchmark::State& state) {
   int x_dim = state.range(0);
   int y_dim = state.range(1);
   int z_dim = state.range(2);
@@ -23,14 +23,9 @@ static void BM_GetMap(benchmark::State& state) {
                                   decay_times);
 
   for (auto _ : state) {
-    test_mapper.getMap();
+    test_mapper.getInflatedMap();
   }
 }
-
-BENCHMARK(BM_GetMap)
-  ->Args({200, 200, 10, 50})
-  ->Args({200, 200, 10, 25})
-  ->Args({200, 200, 10, 10});
 
 
 /**
@@ -61,11 +56,6 @@ static void BM_DecayLocalCloud(benchmark::State& state) {
     test_mapper.decayLocalCloud(position, max_range);
   }
 }
-
-BENCHMARK(BM_DecayLocalCloud)
-  ->Args({200, 200, 10, 50})
-  ->Args({200, 200, 10, 25})
-  ->Args({200, 200, 10, 10});
 
 
 /**
@@ -126,11 +116,6 @@ static void BM_AddCloud(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_AddCloud)
-  ->Args({200, 200, 10, 50})
-  ->Args({200, 200, 10, 25})
-  ->Args({200, 200, 10, 10});
-
 
 /**
  * @brief Arguments represent the x-dim, y-dim, and z-dim size respectively. The
@@ -161,42 +146,28 @@ static void BM_GetInflatedLocalMap(benchmark::State& state) {
   }
 }
 
+
+BENCHMARK(BM_GetInflatedMap)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
+BENCHMARK(BM_DecayLocalCloud)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
+BENCHMARK(BM_AddCloud)
+  ->Args({200, 200, 10, 50})
+  ->Args({200, 200, 10, 25})
+  ->Args({200, 200, 10, 10});
+
 BENCHMARK(BM_GetInflatedLocalMap)
   ->Args({200, 200, 10, 50})
   ->Args({200, 200, 10, 25})
   ->Args({200, 200, 10, 10});
 
 
-// class VoxelMapperBenchmark : public benchmark::Fixture {
-//  public:
-//   void SetUp(const ::benchmark::State& state) {
-//     int x_origin_ = -100;
-//     int y_origin_ = -100;
-//     int z_origin_ = -5;
-//     int x_dim_ = 200;
-//     int y_dim_ = 200;
-//     int z_dim_ = 10;
-//     double resolution_ = 0.5;
-//     int8_t val_default_ = 0;
-//     int decay_times_ = 30;
-//     Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
-//     Eigen::Vector3d dimensions(x_dim_, y_dim_, z_dim_);
-//     p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions,
-//                                         resolution_, val_default_,
-//                                         decay_times_));
-//   }
-
-//   std::unique_ptr<mapper::VoxelMapper> p_test_mapper_;  
-
-// };
-
-// BENCHMARK_DEFINE_F(VoxelMapperBenchmark, GetMapTest)(benchmark::State& st) {
-//   for (auto _ : st) {
-//     p_test_mapper_->getMap();
-//   }
-// }
-
-// BENCHMARK_REGISTER_F(VoxelMapperBenchmark, GetMapTest);
-
-
 BENCHMARK_MAIN();
+
+

--- a/autonomy_core/map_plan/mapper/test/benchmark_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/benchmark_voxel_mapper.cpp
@@ -75,6 +75,8 @@ static void BM_AddCloud(benchmark::State& state) {
   int decay_times = 30;
   Eigen::Vector3d origin(x_origin, y_origin, z_origin);
   Eigen::Vector3d dimensions(x_dim, y_dim, z_dim);
+
+  // Create the voxel mapper object
   mapper::VoxelMapper test_mapper(origin, dimensions,
                                   resolution, val_default,
                                   decay_times);

--- a/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
@@ -78,7 +78,7 @@ class VoxelMapperTest : public testing::Test {
 /**
  * @brief Used for debugging purposes. When a test fails this function can be
  * used to retrieve the corresponding voxel index from a linear indexing value
- * @param index index of voxel stored in contiguous memory
+ * @param index Index of voxel stored in contiguous memory
  * @return Eigen::Vector3i : Voxel index
  */
 Eigen::Vector3i VoxelMapperTest::getVoxel(int index) {
@@ -108,12 +108,12 @@ void VoxelMapperTest::SetUp() {
     p_test_mapper_.reset( new mapper::VoxelMapper(origin, dimensions,
                                                   resolution_, val_default_,
                                                   decay_times_));
-    val_occ_ = p_test_mapper_->val_occ;
-    val_even_ = p_test_mapper_->val_even;
-    val_add_ = p_test_mapper_->val_add;
-    val_unknown_ = p_test_mapper_->val_unknown;
-    val_free_ = p_test_mapper_->val_free;
-    val_decay_ = p_test_mapper_->val_decay;
+    val_occ_        = p_test_mapper_->val_occ_;
+    val_even_       = p_test_mapper_->val_even_;
+    val_add_        = p_test_mapper_->val_add_;
+    val_unknown_    = p_test_mapper_->val_unknown_;
+    val_free_       = p_test_mapper_->val_free_;
+    val_decay_      = p_test_mapper_->val_decay_;
 
     // Fill the cloud with some random known points
     gt_cloud_.push_back(Eigen::Vector3d(0.25, 0.25, 0.25));
@@ -184,7 +184,7 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
     // what they previously were
     Eigen::Vector3d prev_origin(x_origin_, y_origin_, z_origin_);
     Eigen::Vector3d prev_dimensions(x_dim_, y_dim_, z_dim_);
-    ASSERT_FALSE(p_test_mapper_->allocate(prev_dimensions, prev_origin));
+    ASSERT_FALSE(p_test_mapper_->allocate(prev_origin, prev_dimensions));
 
     // Mark all voxels as occupied. This original map, in world coordinates,
     // ranges from:
@@ -210,7 +210,7 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
     Eigen::Vector3d new_origin(0, 0, 0);
     Eigen::Vector3d new_dimensions(150, 150, 10);
     // True means that the relocating actually happened
-    EXPECT_TRUE(p_test_mapper_->allocate(new_dimensions, new_origin));
+    EXPECT_TRUE(p_test_mapper_->allocate(new_origin, new_dimensions));
 
     planning_ros_msgs::VoxelMap relocated_map = p_test_mapper_->getMap();
 
@@ -675,8 +675,7 @@ TEST_F(VoxelMapperTest, TestGetLocalCloud) {
     Eigen::Vector3d origin(-35, -50, 1);
     Eigen::Vector3d dimensions(70, 75, 3.4);
     vec_Vec3d point_cloud =
-        p_test_mapper_->getLocalCloud(Eigen::Vector3d(0, 0, 0),
-                                      origin, dimensions);
+        p_test_mapper_->getLocalCloud(origin, dimensions);
 
     // Create the local ground truth cloud
     vec_Vec3d gt_local_cloud;
@@ -730,8 +729,7 @@ TEST_F(VoxelMapperTest, TestGetInflatedLocalCloud) {
     Eigen::Vector3d origin(-35, -50, 1);
     Eigen::Vector3d dimensions(70, 75, 3.4);
     vec_Vec3d point_cloud =
-        p_test_mapper_->getInflatedLocalCloud(Eigen::Vector3d(0, 0, 0),
-                                      origin, dimensions);
+        p_test_mapper_->getInflatedLocalCloud(origin, dimensions);
 
     // Create the local ground truth cloud
     vec_Vec3d gt_local_cloud;

--- a/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
@@ -4,6 +4,41 @@
 #include <cmath>
 #include <memory>
 #include "mapper/voxel_mapper.h"
+#include "mpl_collision/map_util.h"
+
+/**
+ * @brief This function is passed as a parameter to the sort method so that
+ * points in a point cloud can be sorted. Points are first compared by their
+ * first axis and consequently compared through their next axis if the previous
+ * are equal 
+ * @param first : first element to compare
+ * @param second : second element to compare
+ * @return returns true if the first parameter is smaller than the second
+ * and false otherwise
+ */
+bool comparePoints(Eigen::Vector3d first, Eigen::Vector3d second) {
+    const double epsilon = 0.000001;
+
+    if (fabs(first[0] - second[0]) < epsilon) {
+        // Index 0 is the same so check next index
+        if (fabs(first[1] - second[1]) < epsilon) {
+            // Index 1 is the same so check the last index
+            if (fabs(first[2] - second[2]) < epsilon) {
+                // All elements are equal
+                return false;
+            } else {
+                // Points differ at index 2 so compare them normally
+                return first[2] < second[2];
+            }
+        } else {
+            // Points differ at index 1 so compare them normally
+            return first[1] < second[1];
+        }
+    } else {
+        // They are not equal so compare them normally
+        return first[0] < second[0];
+    }
+}
 
 
 // Test class needs to be in the same namespace as VoxelMapper to be able to
@@ -14,10 +49,13 @@ namespace mapper {
 class VoxelMapperTest : public testing::Test {
  protected:
     void SetUp() override;
+    Eigen::Vector3i getVoxel(int index);
 
+    // The origin is the most negative corner
     double x_origin_;
     double y_origin_;
     double z_origin_;
+    // Dimensions along each axis (NOT amount of voxels in each axis)
     int x_dim_;
     int y_dim_;
     int z_dim_;
@@ -26,11 +64,34 @@ class VoxelMapperTest : public testing::Test {
     int8_t val_occ_;
     int8_t val_even_;
     int8_t val_add_;
+    int8_t val_unknown_;
+    int8_t val_free_;
+    int8_t val_decay_;
     int decay_times_;
+
+    vec_Vec3d gt_cloud_;     // Ground truth point cloud for some tests
 
     // This is the VoxelMapper object that is used for all the tests
     std::unique_ptr<mapper::VoxelMapper> p_test_mapper_;
 };
+
+/**
+ * @brief Used for debugging purposes. When a test fails this function can be
+ * used to retrieve the corresponding voxel index from a linear indexing value
+ * @param index index of voxel stored in contiguous memory
+ * @return Eigen::Vector3i : Voxel index
+ */
+Eigen::Vector3i VoxelMapperTest::getVoxel(int index) {
+    Eigen::Vector3i voxel;
+    int x_voxels = x_dim_ / resolution_;
+    int y_voxels = y_dim_ / resolution_;
+    voxel[2] = index / (x_voxels * y_voxels);
+    index = index % (x_voxels * y_voxels);
+    voxel[1] = index / x_voxels;
+    voxel[0] = index % x_voxels;
+
+    return voxel;
+}
 
 void VoxelMapperTest::SetUp() {
     x_origin_ = -100;
@@ -50,6 +111,25 @@ void VoxelMapperTest::SetUp() {
     val_occ_ = p_test_mapper_->val_occ;
     val_even_ = p_test_mapper_->val_even;
     val_add_ = p_test_mapper_->val_add;
+    val_unknown_ = p_test_mapper_->val_unknown;
+    val_free_ = p_test_mapper_->val_free;
+    val_decay_ = p_test_mapper_->val_decay;
+
+    // Fill the cloud with some random known points
+    gt_cloud_.push_back(Eigen::Vector3d(0.25, 0.25, 0.25));
+    gt_cloud_.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
+    gt_cloud_.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
+    gt_cloud_.push_back(Eigen::Vector3d(20.25, 66.25, 4.25));
+    gt_cloud_.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
+    gt_cloud_.push_back(Eigen::Vector3d(85.25, -61.25, 2.25));
+    gt_cloud_.push_back(Eigen::Vector3d(94.25, -76.25, -3.25));
+    gt_cloud_.push_back(Eigen::Vector3d(-64.25, 58.25, -4.75));
+    gt_cloud_.push_back(Eigen::Vector3d(34.25, 34.25, -3.25));
+    gt_cloud_.push_back(Eigen::Vector3d(79.25, 12.25, -2.25));
+
+    // Cloud is sorted because it should not matter in what order the points
+    // in point clouds returned by class methods
+    std::sort(gt_cloud_.begin(), gt_cloud_.end(), comparePoints);
 }
 
 
@@ -59,10 +139,10 @@ void VoxelMapperTest::SetUp() {
  * @brief The allocate() method is able to relocate the current map into another
  * part of the world, but this functionality is currently NOT being used since
  * allocate() is only called in the constructor of the VoxelMapper class. The
- * map is stored in the map_ data member and we could access it directly via
+ * map is stored in the map_ data member and we can access it directly via
  * friendship to verify the correct initialization of allocate(), but this test
  * should not depend on the data type of the map_ variable; for this reason, we
- * use the getMap() method to check the status of the map. In the first three
+ * use the getMap() method to check the status of the map. In the following
  * assertions, we check that the map is created with the correct dimensions.
  */
 TEST_F(VoxelMapperTest, TestAllocateDimensions) {
@@ -92,9 +172,20 @@ TEST_F(VoxelMapperTest, TestAllocateDimensions) {
 
 /**
  * @brief Similar to TestAllocateDimensions but here we test that the relocating
- * of the map is working properly. 
+ * of the map is working properly. When relocating the map to a new area in
+ * the world, the new voxels are initialized to the default value, but the
+ * overlapping voxels retain their previous values. So we first create a map and
+ * mark all of its voxels as occupied. Then we relocate the map so that it
+ * partially overlaps with its orginal position. The voxels that are overlapped
+ * should be kept as occupied and the new voxels should have the defualt value.
  */
 TEST_F(VoxelMapperTest, TestAllocateRelocate) {
+    // Relocating should not happen if origin and dimensions are the same as to
+    // what they previously were
+    Eigen::Vector3d prev_origin(x_origin_, y_origin_, z_origin_);
+    Eigen::Vector3d prev_dimensions(x_dim_, y_dim_, z_dim_);
+    ASSERT_FALSE(p_test_mapper_->allocate(prev_dimensions, prev_origin));
+
     // Mark all voxels as occupied. This original map, in world coordinates,
     // ranges from:
     // x: -100 to 100
@@ -105,12 +196,17 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
     // y: 200 voxels from -100 to 0 and 200 voxels from 0 to 100
     // z: 10 voxels from -5 to 0 and 10 voxels from 0 to 5
     int num_voxels = 3200000;
-    std::fill(p_test_mapper_->map_.data(),
-              p_test_mapper_->map_.data() + num_voxels, val_occ_);
+    std::vector<signed char> base_map(num_voxels, val_occ_);
+    Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
+    Eigen::Vector3i dimensions(x_dim_ / resolution_,
+                               y_dim_ / resolution_,
+                               z_dim_ / resolution_);
+    p_test_mapper_->setMap(origin, dimensions, base_map, resolution_);
 
-    // Relocating map in the positive direction in all three axes centered at
-    // (0,0,0) and reducing x-dim and y-dim by 50. With the same resolution this
-    // means 100 less voxels in each dimension. z stays the same
+    // Relocating map in the positive direction in all three axes with its most
+    // negative corner at (0, 0, 0) and reducing x-dim and y-dim by 50. With the
+    // same resolution this means 100 less voxels in each dimension.
+    // z stays the same
     Eigen::Vector3d new_origin(0, 0, 0);
     Eigen::Vector3d new_dimensions(150, 150, 10);
     // True means that the relocating actually happened
@@ -118,13 +214,12 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
 
     planning_ros_msgs::VoxelMap relocated_map = p_test_mapper_->getMap();
 
-    // Create the ground truth voxel map to compare the relocated map to
+    // Create the ground truth voxel map to compare it to the relocated map
     planning_ros_msgs::VoxelMap gt_voxel_map;
-    // new map should have 300 voxels in x dimension
+
+    // new map should have 300 voxels in x, 300 voxels in the y, and 20 in z
     int dim_x = 150 / resolution_;
-    // new map should have 300 voxels in y dimension
     int dim_y = 150 / resolution_;
-    // new map should have 20 voxels in z dimension
     int dim_z = 10 / resolution_;
     gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_default_);
 
@@ -137,23 +232,62 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
     // z: 0 to 10
     // Given the previous location and that all the voxels there were occupied,
     // the new map has
-    // x: 200 voxels marked as occupied and 100 as default
-    // y: 200 voxels marked as occupied and 100 as default
-    // z: 10 voxels marked as occupied and 10 as default
+    // x: The first 200 voxels marked as occupied and the last 100 as default
+    // y: The first 200 voxels marked as occupied and the last 100 as default
+    // z: The first 10 voxels marked as occupied and the last 10 as default
     // so set that for the ground truth voxel map
     for (int x = 0 ; x < 200; x++) {
         for (int y = 0; y < 200; y++) {
             for (int z = 0; z < 10; z++) {
-                int idx = x + 300 * y + 300 * 300 * z;
+                int idx = x + dim_x * y + dim_x * dim_y * z;
                 gt_voxel_map.data[idx] = val_occ_;
             }
         }
     }
-    num_voxels = relocated_map.data.size();
+
+    num_voxels = gt_voxel_map.data.size();
     ASSERT_EQ(relocated_map.data.size(), gt_voxel_map.data.size());
+
     for (int idx = 0; idx < num_voxels; idx++) {
-        EXPECT_EQ(relocated_map.data[idx], gt_voxel_map.data[idx]) << "IDX: "
-                                                                   << idx;
+        auto voxel = getVoxel(idx);
+        EXPECT_EQ(relocated_map.data[idx], gt_voxel_map.data[idx])
+            << "IDX:" << idx << "\t"
+            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+            << "]" << std::endl;
+    }
+}
+
+/**
+ * @brief In this test we make sure that after calling setMapUnkown, all voxels
+ * in the map and the inflated map are marked as unknown
+ */
+TEST_F(VoxelMapperTest, TestSetMapUknown) {
+    p_test_mapper_->setMapUnknown();
+    planning_ros_msgs::VoxelMap vox_map = p_test_mapper_->getMap();
+    planning_ros_msgs::VoxelMap inflated_vox_map =
+                                    p_test_mapper_->getInflatedMap();
+    for (auto &voxel : vox_map.data) {
+        EXPECT_EQ(voxel, val_unknown_);
+    }
+    for (auto &voxel : inflated_vox_map.data) {
+        EXPECT_EQ(voxel, val_unknown_);
+    }
+}
+
+/**
+ * @brief In this test we make sure that after calling setMapFree, all voxels
+ * in the map and the inflated map are marked as free
+ */
+TEST_F(VoxelMapperTest, TestSetMapFree) {
+    p_test_mapper_->setMapFree();
+    planning_ros_msgs::VoxelMap vox_map = p_test_mapper_->getMap();
+    planning_ros_msgs::VoxelMap inflated_vox_map =
+                                    p_test_mapper_->getInflatedMap();
+    for (auto &voxel : vox_map.data) {
+        EXPECT_EQ(voxel, val_free_);
+    }
+    for (auto &voxel : inflated_vox_map.data) {
+        EXPECT_EQ(voxel, val_free_);
     }
 }
 
@@ -162,27 +296,32 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
  * local range. So first we mark all the voxels in the map as occupied and call
  * decayLocalCloud multiple times. Since getMap doesn't return the exact value
  * of the voxel, we will call decayLocalCloud until the in-range voxels are
- * equal to val_even; this corresponds to calling decayLocalCloud a total of
+ * equal to val_even (voxels equal to or below this value are considered free).
+ * This corresponds to calling decayLocalCloud a total of
  * (val_occ - val_even)/decay_times_ times. Only the voxels that are within
  * range should be decayed and marked as free, while the rest should remain as
  * occupied 
  */
 TEST_F(VoxelMapperTest, TestDecayLocalCloud) {
     // Compute how many times decayLocalCloud must be called to free the voxels
-    int num_calls = (static_cast<float>(p_test_mapper_->val_occ)
-                     - static_cast<float>(p_test_mapper_->val_even))
-                     / static_cast<float>(p_test_mapper_->val_decay);
+    int num_calls = (static_cast<float>(val_occ_)
+                     - static_cast<float>(val_even_))
+                     / static_cast<float>(val_decay_);
 
     // Mark all voxels in the map as occupied
     int num_voxels = 3200000;
-    std::fill(p_test_mapper_->map_.data(),
-              p_test_mapper_->map_.data() + num_voxels,
-              p_test_mapper_->val_occ);
+    std::vector<signed char> base_map(num_voxels, val_occ_);
+    Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
+    Eigen::Vector3i dimensions(x_dim_ / resolution_,
+                               y_dim_ / resolution_,
+                               z_dim_ / resolution_);
+    p_test_mapper_->setMap(origin, dimensions, base_map, resolution_);
 
-    // Now decay the voxels that are in the range of 9.8 in all three axes
-    // around (0, 0, 0)
+    // Now decay the voxels that are in the range of 9.1 in all three axes
+    // around (0, 0, 0) in world coordinates. This corresponds to the lidar's
+    // position in the map's frame of reference
     Eigen::Vector3d position(0, 0, 0);
-    double max_range = 9.8;
+    double max_range = 9.1;
     for (int i = 0; i < num_calls; i++) {
         p_test_mapper_->decayLocalCloud(position, max_range);
     }
@@ -195,14 +334,14 @@ TEST_F(VoxelMapperTest, TestDecayLocalCloud) {
     int dim_y = y_dim_ / resolution_;
     int dim_z = z_dim_ / resolution_;
     // All voxels should be marked occupied except the decayed voxel locations
-    gt_voxel_map.data.resize(dim_x * dim_y * dim_z, p_test_mapper_->val_occ);
+    gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_occ_);
 
     // Free the voxels that should be decayed
-    for (int x = 180; x < 219; x++) {
-        for (int y = 180; y < 219; y++) {
-            for (int z = 0; z < 20; z++) {
+    for (int x = 181; x <= 218; x++) {
+        for (int y = 181; y <= 218; y++) {
+            for (int z = 0; z <= 19; z++) {
                 int idx = x + 400 * y + 400 * 400 * z;
-                gt_voxel_map.data[idx] = p_test_mapper_->val_free;
+                gt_voxel_map.data[idx] = val_free_;
             }
         }
     }
@@ -210,57 +349,59 @@ TEST_F(VoxelMapperTest, TestDecayLocalCloud) {
     // Finally make the comparison
     ASSERT_EQ(decayed_map.data.size(), gt_voxel_map.data.size());
     for (int idx = 0; idx < num_voxels; idx++) {
-        EXPECT_EQ(decayed_map.data[idx], gt_voxel_map.data[idx]) << "IDX: "
-                                                                 << idx;
+        auto voxel = getVoxel(idx);
+        EXPECT_EQ(decayed_map.data[idx], gt_voxel_map.data[idx])
+            << "IDX:" << idx << "\t"
+            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+            << "]" << std::endl;
     }
 }
 
 /**
  * @brief This method is called to process the point cloud from the lidar scans.
  * Currently, raytracing is always set to false, so it is never called. The
- * decayLocalCloud method is called inside this method, but since the decay
- * value is 2, it does not impede a voxel from being marked as occupied after
- * one scan if we include 3 lidar points in the specified voxel. Points are
- * provided with respect to the lidar frame and the transformation that is
- * passed as an argument is the pose of the lidar in the map frame. Any points
- * outside of max_range are discarded. In this test, we simulate the lidar to be
- * at a world coordinate different than (0, 0, 0) and make a single call to
- * addCloud. This represents a single lidar scan, but to make sure that the
- * voxels corresponding to the points are marked as occupied in this single
- * scan, we triplicate the points. After making the call we compare the normal
- * map and the inflated map to their ground truths.
+ * decayLocalCloud method is called inside this method, so we take this into
+ * consideration for the test. Points are provided with respect to the lidar
+ * frame and the transformation that is passed as an argument is the pose of the
+ * lidar in the map frame. Any points outside of max_range are discarded. In
+ * this test, we simulate the lidar to be at a world coordinate different than
+ * (0, 0, 0) and make a single call to addCloud. This represents a single lidar
+ * scan, but to make sure that the voxels corresponding to the points are marked
+ * as occupied in this single scan, we multiply the points by the necessary
+ * amount to condsider a voxel occupied. After making the call we compare the
+ * normal map and the inflated map to their ground truths.
  */
 TEST_F(VoxelMapperTest, TestAddCloud) {
-    // We will consider that the lidar is at position (-10, -5, -1) in the map
-    // frame of reference
+    // We will consider that the lidar is at position (-10, -5, -1) without any
+    // rotation in the map frame of reference
     Eigen::Vector3d lidar_pos(-10, -5, -1);
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(-10, -5, -1) *
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(lidar_pos) *
                                   Eigen::AngleAxisd(0,
                                                     Eigen::Vector3d(0, 0, 0));
-    double max_range = 30.0;
+    double max_range = 3.0;
     vec_Vec3d lidar_points;
 
-    // Number of points need for one scan to mark voxel as occupied
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
     int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add 3 points for all voxels in the range -30 to 30 in all 3 axes. Some
-    // will be discarded and only a sperical shape of voxels around
-    // (-10, -5, -1) should be marked as occupied
-    for (int x = 0; x <= 120; x++) {
-        for (int y = 0; y <= 120; y++) {
-            for (int z = 0; z <= 120; z++) {
-                double real_x = -30 + x * 0.5;
-                double real_y = -30 + y * 0.5;
-                double real_z = -30 + z * 0.5;
-                Eigen::Vector3d point(real_x, real_y, real_z);
-                for (int n = 0; n < 3; n++) {
-                    lidar_points.push_back(point);
-                }
-            }
+    // Add num_points+1 points for 20 voxels in the positive and negative
+    // direction along all 3 axes. Note that these points are with respect to
+    // the lidar frame which is at position (-10, -5, -1) in the world frame
+    for (int k = -20; k < 20; k++) {
+        double real_k = k * 0.5 + 0.25;
+        Eigen::Vector3d point_x(real_k, 0, 0);
+        Eigen::Vector3d point_y(0, real_k, 0);
+        Eigen::Vector3d point_z(0, 0, real_k);
+        for (int n = 0; n < num_points + 1; n++) {
+            lidar_points.push_back(point_x);
+            lidar_points.push_back(point_y);
+            lidar_points.push_back(point_z);
         }
     }
 
-    // Current neighboring voxels are just +-1 in x and y directions
+    // Current neighboring voxels for global map are just +-1 in x and y
+    // directions, so replicate this for tests
     vec_Vec3i neighbors;
     neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
     neighbors.push_back(Eigen::Vector3i(1, 0, 0));
@@ -283,30 +424,33 @@ TEST_F(VoxelMapperTest, TestAddCloud) {
     gt_voxel_map.data.resize(x_dim * y_dim * z_dim, val_default_);
     gt_inflated_voxel_map.data.resize(x_dim * y_dim * z_dim, val_default_);
 
-    // Fill the voxels that should be occupied
-    for (int x = 0; x < x_dim; x++) {
-        for (int y = 0; y < y_dim; y++) {
-            for (int z = 0; z < z_dim; z++) {
-                Eigen::Vector3d voxel_pos = Eigen::Vector3d(x, y, z) *
-                                            resolution_ +
-                                            Eigen::Vector3d(x_origin_,
-                                                            y_origin_,
-                                                            z_origin_);
-                if ((voxel_pos - lidar_pos).norm() <= max_range) {
-                    int idx = x + x_dim * y + x_dim * y_dim * z;
-                    gt_voxel_map.data[idx] = gt_voxel_map.val_occ;
-                    gt_inflated_voxel_map.data[idx] = gt_voxel_map.val_occ;
+    // Fill the voxels that should be occupied. To know which voxels should be
+    // occupied, consider the pose of the lidar and the max range of the points
+    // meaning some points should be filtered out. The lidar position
+    // (-10, -5, -1) lies at the most negative corners of voxels
+    // X: 180, Y: 190, Z: 8 and with a range of 3 for the points, that is 6
+    // voxels towards each direction
+    Eigen::Vector3i voxel_start(180, 190, 8);
+    std::vector<std::vector<int>> ranges{{174, 185}, {184, 195}, {2, 13}};
 
-                    // Include neighbors for the inflated map
-                    Eigen::Vector3i current_voxel(x, y, z);
-                    for (auto &neighbor : neighbors) {
-                        Eigen::Vector3i neigbor_voxel = current_voxel +
-                                                        neighbor;
-                        int idx = neigbor_voxel(0) + x_dim * neigbor_voxel(1)
-                                  + x_dim * y_dim * neigbor_voxel(2);
-                        gt_inflated_voxel_map.data[idx] = gt_voxel_map.val_occ;
-                    }
-                }
+    for (int i = 0; i < 3; i++) {
+        // While iterating through each range, keep the other two axes static
+        for (int k = ranges[i][0]; k <= ranges[i][1]; k++) {
+            int x = i == 0 ? k : voxel_start[0];
+            int y = i == 1 ? k : voxel_start[1];
+            int z = i == 2 ? k : voxel_start[2];
+
+            int idx = x + x_dim * y + x_dim * y_dim * z;
+            gt_voxel_map.data[idx] = val_occ_;
+            gt_inflated_voxel_map.data[idx] = val_occ_;
+
+            // Include neighbors for the inflated map
+            Eigen::Vector3i current_voxel(x, y, z);
+            for (auto &neighbor : neighbors) {
+                Eigen::Vector3i neighbor_voxel = current_voxel + neighbor;
+                int idx = neighbor_voxel(0) + x_dim * neighbor_voxel(1)
+                            + x_dim * y_dim * neighbor_voxel(2);
+                gt_inflated_voxel_map.data[idx] = val_occ_;
             }
         }
     }
@@ -315,24 +459,32 @@ TEST_F(VoxelMapperTest, TestAddCloud) {
     int num_voxels = x_dim * y_dim * z_dim;
     ASSERT_EQ(processed_map.data.size(), gt_voxel_map.data.size());
     for (int idx = 0; idx < num_voxels; idx++) {
-        EXPECT_EQ(processed_map.data[idx], gt_voxel_map.data[idx]) << "IDX: "
-                                                                   << idx;
+        auto voxel = getVoxel(idx);
+        EXPECT_EQ(processed_map.data[idx], gt_voxel_map.data[idx])
+            << "IDX:" << idx << "\t"
+            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+            << "]" << std::endl;
     }
 
     // Compare the inflated map
     ASSERT_EQ(processed_inflated_map.data.size(),
               gt_inflated_voxel_map.data.size());
     for (int idx = 0; idx < num_voxels; idx++) {
+        auto voxel = getVoxel(idx);
         EXPECT_EQ(processed_inflated_map.data[idx],
-                  gt_inflated_voxel_map.data[idx]) << "IDX: " << idx;
+                  gt_inflated_voxel_map.data[idx])
+            << "IDX:" << idx << "\t"
+            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+            << "]" << std::endl;
     }
 }
 
 /**
- * @brief If no point cloud has been processed, then the inflated map and the normal map
- * are identical. The processing of the cloud is tested separately so here we are just going to
- * make sure that the two maps are indeed identical upon initialization. Initialization is done
- * in the constructor so here we will just compare the maps.
+ * @brief If no point cloud has been processed, then the inflated map and the
+ * normal map are identical. The processing of the cloud is tested separately so
+ * here we are just going to make sure that the two maps are indeed identical
+ * upon initialization. Initialization is done in the constructor so here we
+ * will just compare the maps to each other after being created.
  */
 TEST_F(VoxelMapperTest, TestGetInflatedMap) {
     planning_ros_msgs::VoxelMap normal_map = p_test_mapper_->getMap();
@@ -342,28 +494,31 @@ TEST_F(VoxelMapperTest, TestGetInflatedMap) {
     ASSERT_EQ(normal_map.data.size(), num_voxels);
     ASSERT_EQ(normal_map.data.size(), inflated_map.data.size());
     for (int idx = 0; idx < num_voxels; idx++) {
-        EXPECT_EQ(normal_map.data[idx], inflated_map.data[idx]) << "IDX: "
-                                                                << idx;
+        auto voxel = getVoxel(idx);
+        EXPECT_EQ(normal_map.data[idx], inflated_map.data[idx])
+            << "IDX:" << idx << "\t"
+            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+            << "]" << std::endl;
     }
 }
 
 /**
- * @brief This method extracts a portion of the world with a world origin and
- * map dimensions provided as arguments. The resolution is the same as the
- * inflated map and it will retrieve the inflated map, similar to the
- * getInflatedMap method. One key difference is that any voxels that are outside
- * the bounds of the inflated map are considered as occupied. In this test,
- * given the map created with all voxels set to default, we extract a local map
- * that is partially outside the bounds of the intial map. So the extracted
- * local map should have the overlapping voxels set to the default value while
- * all other voxels set to occupied.
+ * @brief This method extracts a portion of the world. It will retrieve a map
+ * that is cropped out of the inflated map. The function takes as arguments an
+ * origin and dimensions for the cropped map, but the resolution is the same as
+ * the inflated map. One key difference is that any voxels that are outside
+ * the bounds of the cropped inflated map are considered as occupied. In this
+ * test, given the default map that is created with all voxels set to default
+ * value, we extract a local map that is partially outside the bounds of the
+ * intial map. So the extracted local map should have the overlapping voxels set
+ * to the default value while all other voxels set to occupied.
  */
 TEST_F(VoxelMapperTest, TestGetInflatedLocalMap) {
     // The origin of the local map is moved in the positive direction in all
     // three axes by different amounts. This will cause a portion of the local
     // map to overlap with the original map.
-    Eigen::Vector3d origin(75, 25, 2.5);
-    Eigen::Vector3d dimensions(100, 100, 10);
+    Eigen::Vector3d origin(75, 25, 2.5);    // Prev origin was (-100, -100, -5)
+    Eigen::Vector3d dimensions(100, 100, 10);   // Prev dimen was (200, 200, 10)
 
     planning_ros_msgs::VoxelMap local_map;
     local_map = p_test_mapper_->getInflatedLocalMap(origin, dimensions);
@@ -375,6 +530,7 @@ TEST_F(VoxelMapperTest, TestGetInflatedLocalMap) {
     int dim_z = dimensions(2) / resolution_;
     gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_occ_);
 
+    // Set the overlapping voxels to the default value
     for (int x = 0; x < 50; x++) {          // 200 - 150 = 50
         for (int y = 0; y < 150; y++) {     // 200 - 50 = 150
             for (int z = 0; z < 5; z++) {   // 10 - 5 = 5
@@ -388,12 +544,412 @@ TEST_F(VoxelMapperTest, TestGetInflatedLocalMap) {
     int num_voxels = dim_x * dim_y * dim_z;
     ASSERT_EQ(local_map.data.size(), gt_voxel_map.data.size());
     for (int idx = 0; idx < num_voxels; idx++) {
-        EXPECT_EQ(local_map.data[idx], gt_voxel_map.data[idx]) << "IDX: "
-                                                               << idx;
+        auto voxel = getVoxel(idx);
+        EXPECT_EQ(local_map.data[idx], gt_voxel_map.data[idx])
+            << "IDX:" << idx << "\t"
+            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+            << "]" << std::endl;
+    }
+}
+
+/**
+ * @brief In this test, we check that the cloud is retrieved correctly.
+ * For every voxel that is occupied in the map, a point lying at the
+ * center of the voxel should be included in the returned cloud.
+ */
+TEST_F(VoxelMapperTest, TestGetCloud) {
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
+    int num_points = (val_occ_ - val_even_) / val_add_;
+
+    // Add num_points+1 points for all points in gt_cloud
+    vec_Vec3d scan_points;
+    for (auto &point : gt_cloud_) {
+        for (int n = 0; n < num_points + 1; n++) {
+            scan_points.push_back(point);
+        }
+    }
+
+    // No neighboring voxels for inflated map, lidar pose is at the origin,
+    // no raytracing and the max range is large enough to avoid filtering out
+    // any point within the bounds of the map
+    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+
+    vec_Vec3d point_cloud = p_test_mapper_->getCloud();
+
+    // Sort the received point cloud to compare it to the ground truth point
+    // cloud. We sort because it should not matter in what order the points
+    // are received
+    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+
+    ASSERT_EQ(point_cloud.size(), gt_cloud_.size());
+    // Iterate over every point
+    for (int i = 0; i < gt_cloud_.size(); i++) {
+        // iterate over every index in each point
+        for (int n = 0; n < 3; n++) {
+            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_cloud_[i][n])
+                << "IDX: " << i << ", Axis: " << n << std::endl;
+        }
+    }
+}
+
+/**
+ * @brief In this test, we check that the inflated cloud is retrieved correctly.
+ * For every voxel that is occupied in the inflated map, a point lying at the
+ * center of the voxel should be included in the returned cloud.
+ */
+TEST_F(VoxelMapperTest, TestGetInflatedCloud) {
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
+    int num_points = (val_occ_ - val_even_) / val_add_;
+
+    // Add num_points+1 points for all points in gt_cloud
+    vec_Vec3d scan_points;
+    for (auto &point : gt_cloud_) {
+        for (int n = 0; n < num_points + 1; n++) {
+            scan_points.push_back(point);
+        }
+    }
+
+    // No neighboring voxels for inflated map, lidar pose is at the origin,
+    // no raytracing and the max range is large enough to avoid filtering out
+    // any point within the bounds of the map
+    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+
+    vec_Vec3d point_cloud = p_test_mapper_->getInflatedCloud();
+
+    // Sort the received point cloud to compare it to the ground truth point
+    // cloud. We sort because it should not matter in what order the points
+    // are received
+    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+
+    ASSERT_EQ(point_cloud.size(), gt_cloud_.size());
+    // Iterate over every point
+    for (int i = 0; i < gt_cloud_.size(); i++) {
+        // iterate over every index in each point
+        for (int n = 0; n < 3; n++) {
+            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_cloud_[i][n])
+                << "IDX: " << i << ", Axis: " << n << std::endl;
+        }
+    }
+}
+
+/**
+ * @brief Similar to the getCloud and getInflatedCloud tests, here we retrieve
+ * a cloud in a cropped out section of the map. We choose a position and
+ * dimensions making sure that we only encapsulate some of the points in the
+ * ground truth cloud. We first add the points from the ground truth cloud by
+ * calling addCloud. Then we create the local ground truth since not all points
+ * should be returned when calling getLocalCloud.
+ */
+TEST_F(VoxelMapperTest, TestGetLocalCloud) {
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
+    int num_points = (val_occ_ - val_even_) / val_add_;
+
+    // Add num_points+1 points for all points in gt_cloud
+    vec_Vec3d scan_points;
+    for (auto &point : gt_cloud_) {
+        for (int n = 0; n < num_points + 1; n++) {
+            scan_points.push_back(point);
+        }
+    }
+
+    // No neighboring voxels for inflated map, lidar pose is at the origin,
+    // no raytracing and the max range is large enough to avoid filtering out
+    // any point within the bounds of the map
+    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+
+    // Get points that are within the following bounds:
+    // Lower: [-35, -50, 1]
+    // Upper: [35, 25, 4.4]
+    Eigen::Vector3d origin(-35, -50, 1);
+    Eigen::Vector3d dimensions(70, 75, 3.4);
+    vec_Vec3d point_cloud =
+        p_test_mapper_->getLocalCloud(Eigen::Vector3d(0, 0, 0),
+                                      origin, dimensions);
+
+    // Create the local ground truth cloud
+    vec_Vec3d gt_local_cloud;
+    gt_local_cloud.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
+    gt_local_cloud.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
+    gt_local_cloud.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
+
+    // Sort the received point cloud to compare it to the ground truth point
+    // cloud. We sort because it should not matter in what order the points
+    // are received
+    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+
+    ASSERT_EQ(point_cloud.size(), gt_local_cloud.size());
+    // Iterate over every point
+    for (int i = 0; i < gt_local_cloud.size(); i++) {
+        // iterate over every index in each point
+        for (int n = 0; n < 3; n++) {
+            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_local_cloud[i][n])
+                << "IDX: " << i << ", Axis: " << n << std::endl;
+        }
+    }
+}
+
+/**
+ * @brief Same as TestGetLocalCloud, but for the inflated map
+ */
+TEST_F(VoxelMapperTest, TestGetInflatedLocalCloud) {
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
+    int num_points = (val_occ_ - val_even_) / val_add_;
+
+    // Add num_points+1 points for all points in gt_cloud
+    vec_Vec3d scan_points;
+    for (auto &point : gt_cloud_) {
+        for (int n = 0; n < num_points + 1; n++) {
+            scan_points.push_back(point);
+        }
+    }
+
+    // No neighboring voxels for inflated map, lidar pose is at the origin,
+    // no raytracing and the max range is large enough to avoid filtering out
+    // any point within the bounds of the map
+    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+
+    // Get points that are within the following bounds:
+    // Lower: [-35, -50, 1]
+    // Upper: [35, 25, 4.4]
+    Eigen::Vector3d origin(-35, -50, 1);
+    Eigen::Vector3d dimensions(70, 75, 3.4);
+    vec_Vec3d point_cloud =
+        p_test_mapper_->getInflatedLocalCloud(Eigen::Vector3d(0, 0, 0),
+                                      origin, dimensions);
+
+    // Create the local ground truth cloud
+    vec_Vec3d gt_local_cloud;
+    gt_local_cloud.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
+    gt_local_cloud.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
+    gt_local_cloud.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
+
+    // Sort the received point cloud to compare it to the ground truth point
+    // cloud. We sort because it should not matter in what order the points
+    // are received
+    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+
+    ASSERT_EQ(point_cloud.size(), gt_local_cloud.size());
+    // Iterate over every point
+    for (int i = 0; i < gt_local_cloud.size(); i++) {
+        // iterate over every index in each point
+        for (int n = 0; n < 3; n++) {
+            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_local_cloud[i][n])
+                << "IDX: " << i << ", Axis: " << n << std::endl;
+        }
+    }
+}
+
+/**
+ * @brief The freeVoxels function takes in a single point and free its
+ * corrresponding voxel along with the voxel's neighbors. So in this test we
+ * use the addCloud method to occupy a single voxel and its neighbors.
+ * Then we free it with the freeVoxels method and check if it was done correctly
+ */
+TEST_F(VoxelMapperTest, TestFreeVoxels) {
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
+    int num_points = (val_occ_ - val_even_) / val_add_;
+
+    // Add num_points+1 points for all points in gt_cloud
+    vec_Vec3d scan_points;
+    for (int n = 0; n < num_points + 1; n++) {
+        scan_points.push_back(Eigen::Vector3d(15, 10, 2));
+    }
+
+    // Current neighboring voxels for global map are just +-1 in x and y
+    // directions, so replicate this for tests
+    vec_Vec3i neighbors;
+    neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
+    neighbors.push_back(Eigen::Vector3i(1, 0, 0));
+    neighbors.push_back(Eigen::Vector3i(0, -1, 0));
+    neighbors.push_back(Eigen::Vector3i(0, 1, 0));
+
+    p_test_mapper_->addCloud(scan_points, t_map_lidar, neighbors, false, 180);
+
+    // Make sure that 5 voxels were marked as occupied
+    ASSERT_EQ(p_test_mapper_->getCloud().size(), 1);
+    ASSERT_EQ(p_test_mapper_->getInflatedCloud().size(), 5);
+
+    // Now free the voxels
+    p_test_mapper_->freeVoxels(Eigen::Vector3d(15, 10, 2), neighbors);
+
+    // No voxels should be occupied now
+    ASSERT_EQ(p_test_mapper_->getCloud().size(), 0);
+
+    // If the neighboring voxels in the map are free, then the same voxels in
+    // inflated map are not freed.
+    ASSERT_EQ(p_test_mapper_->getInflatedCloud().size(), 4);
+}
+
+/**
+ * @brief The getInflatedOccMap method returns a 2D slice of the inflated map.
+ * You pass in the z height and the thickness of the slice as parameters. The
+ * thickness refers to how much vertical space is going to be taken into account
+ * to create the 2D slice in either direction. Since it is 2D, there is only one
+ * voxel along the z axis. In this test we use the previously initialized ground
+ * truth cloud to occupy some voxels in the inflated map. Then we select
+ * an arbitrary height and thickness. Finally we create a ground truth 2D map to
+ * compare the results to.
+ */
+TEST_F(VoxelMapperTest, TestgetInflatedOccMap) {
+    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+
+    // There needs to be more than num_points points per voxel to have a single
+    // point cloud set the respective voxels occupied
+    int num_points = (val_occ_ - val_even_) / val_add_;
+
+    // Add num_points+1 points for all points in gt_cloud
+    vec_Vec3d scan_points;
+    for (auto &point : gt_cloud_) {
+        for (int n = 0; n < num_points + 1; n++) {
+            scan_points.push_back(point);
+        }
+    }
+
+    // No neighboring voxels for inflated map, lidar pose is at the origin,
+    // no raytracing and the max range is large enough to avoid filtering out
+    // any point within the bounds of the map
+    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+
+    // Should consider vertical space between [-1.0, 3.5]
+    planning_ros_msgs::VoxelMap sliced_map =\
+        p_test_mapper_->getInflatedOccMap(1.25, 2.25);
+
+    // Create the ground truth voxel map
+    planning_ros_msgs::VoxelMap gt_slice;
+    int x_dim = x_dim_ / resolution_;
+    int y_dim = y_dim_ / resolution_;
+    gt_slice.data.resize(x_dim * y_dim, val_free_);
+
+    // The points occupying a voxel in the previous vertical space are:
+    // (0.25, 0.25, 0.25)       -> voxel indices: [200, 200, 10]
+    // (0.75, 0.75, 1.75)       -> voxel indices: [201, 201, 13]
+    // (-28.25, -12.25, 3.25)   -> voxel indices: [143, 175, 16]
+    // (85.25, -61.25, 2.25)    -> voxel indices: [370, 77, 14]
+    // The returned voxel map uses column-major storage and we also have to
+    // consider axis aligned voxels, so the occupied pixels are computed as
+    // follows: x + x_dim * y, where x and y are the integer indices
+    std::vector<int> indices {80200, 80601, 70143, 31170};
+    for (auto &idx : indices) {
+        gt_slice.data[idx] = val_occ_;
+    }
+
+    // Finally compare the two slices
+    ASSERT_EQ(gt_slice.data.size(), sliced_map.data.size());
+
+    for (int i = 0; i < gt_slice.data.size(); i++) {
+        EXPECT_EQ(gt_slice.data[i], sliced_map.data[i]) << std::endl;
     }
 }
 
 }   // namespace mapper
+
+
+namespace MPL {
+
+/**
+ * @brief map_util considers voxels to be axis-aligned. In this test we make
+ * sure that the conversion from world coordinates to voxel indices and
+ * vice-versa are reciprocal and consistent. We check the use of the
+ * floatToInt and intToFloat functions.
+ */
+TEST(MapUtilTesting, TestVoxelIndexing) {
+    // Create map_util object
+    VoxelMapUtil test_map;
+    // Dimensions are the amount of voxels in each axis
+    test_map.setMap(Vec3f(-100, -100, -5), Vec3i(400, 400, 20), {}, 0.5);
+
+    // Initialize set of points for converstion
+    vec_Vec3f point_cloud;      // Test point cloud
+    vec_Vec3f gt_point_cloud;   // Values that should be returned by intToFloat
+    vec_Vec3i voxel_indices;    // Values that should be returned by floatToInt
+
+    // Test most negative limit of the world
+    point_cloud.push_back(Eigen::Vector3d(-100, -100, -5));
+    gt_point_cloud.push_back(Eigen::Vector3d(-99.75, -99.75, -4.75));
+    voxel_indices.push_back(Eigen::Vector3i(0, 0, 0));
+
+    // Test most positive limit of the world
+    point_cloud.push_back(Eigen::Vector3d(100, 100, 5));
+    gt_point_cloud.push_back(Eigen::Vector3d(100.25, 100.25, 5.25));
+    voxel_indices.push_back(Eigen::Vector3i(400, 400, 20));
+
+    // Test outside the bounds of the world in the positive direction
+    point_cloud.push_back(Eigen::Vector3d(105, 105, 10));
+    gt_point_cloud.push_back(Eigen::Vector3d(105.25, 105.25, 10.25));
+    voxel_indices.push_back(Eigen::Vector3i(410, 410, 30));
+
+    // Test outside the bounds of the world in the most negative direction
+    point_cloud.push_back(Eigen::Vector3d(-105, -105, -10));
+    gt_point_cloud.push_back(Eigen::Vector3d(-104.75, -104.75, -9.75));
+    voxel_indices.push_back(Eigen::Vector3i(-10, -10, -10));
+
+    point_cloud.push_back(Eigen::Vector3d(-100.1, -100.6, -4.9));
+    gt_point_cloud.push_back(Eigen::Vector3d(-100.25, -100.75, -4.75));
+    voxel_indices.push_back(Eigen::Vector3i(-1, -2, 0));
+
+    // Check points near the voxel boundaries to make sure that voxels are
+    // actually axis-aligned and not origin-centered
+    point_cloud.push_back(Eigen::Vector3d(10.1, 10.1, 2));
+    gt_point_cloud.push_back(Eigen::Vector3d(10.25, 10.25, 2.25));
+    voxel_indices.push_back(Eigen::Vector3i(220, 220, 14));
+
+    point_cloud.push_back(Eigen::Vector3d(10.9, 10.9, 2));
+    gt_point_cloud.push_back(Eigen::Vector3d(10.75, 10.75, 2.25));
+    voxel_indices.push_back(Eigen::Vector3i(221, 221, 14));
+
+    point_cloud.push_back(Eigen::Vector3d(5.6, 5.6, 3));
+    gt_point_cloud.push_back(Eigen::Vector3d(5.75, 5.75, 3.25));
+    voxel_indices.push_back(Eigen::Vector3i(211, 211, 16));
+
+    point_cloud.push_back(Eigen::Vector3d(5.4, 5.4, 3));
+    gt_point_cloud.push_back(Eigen::Vector3d(5.25, 5.25, 3.25));
+    voxel_indices.push_back(Eigen::Vector3i(210, 210, 16));
+
+    for (int i = 0; i < point_cloud.size(); i++) {
+        auto &point = point_cloud[i];
+        auto &gt_point = gt_point_cloud[i];
+        auto &voxel = voxel_indices[i];
+        Eigen::Vector3i ret_indices = test_map.floatToInt(point);
+        Eigen::Vector3d ret_point = test_map.intToFloat(ret_indices);
+
+        // Compare the returned indices to the actual voxel indices
+        for (int n = 0; n < 3; n++) {
+            EXPECT_EQ(voxel[n], ret_indices[n]) << "Point idx: " << i
+                << "  Voxel: [" << voxel[0] << ", " << voxel[1] << ", "
+                << voxel[2] << "]" << std::endl;
+        }
+
+        // Compare the original point to the returned point
+        for (int n = 0; n < 3; n++) {
+            EXPECT_DOUBLE_EQ(gt_point[n], ret_point[n]) << "Point idx: " << i
+                << "  Point: [" << point[0] << ", " << point[1] << ", "
+                << point[2] << "]" << std::endl;
+        }
+    }
+}
+
+}   // namespace MPL
 
 int main(int argc, char **argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
@@ -395,4 +395,8 @@ TEST_F(VoxelMapperTest, TestGetInflatedLocalMap) {
 
 }   // namespace mapper
 
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
 

--- a/autonomy_core/map_plan/mpl/include/mpl_collision/map_util.h
+++ b/autonomy_core/map_plan/mpl/include/mpl_collision/map_util.h
@@ -103,4 +103,13 @@ typedef MapUtil<2> OccMapUtil;
 
 typedef MapUtil<3> VoxelMapUtil;
 
+template <int Dim>
+int MapUtil<Dim>::getIndex(const Veci<Dim> &pn) {
+  if constexpr (Dim == 3) {
+    return pn(0) + dim_(0) * pn(1) + dim_(0) * dim_(1) * pn(2);
+  } else {
+    return pn(0) + dim_(0) * pn(1);
+  }
+}
+
 }  // namespace MPL

--- a/autonomy_core/map_plan/mpl/src/map_util.cpp
+++ b/autonomy_core/map_plan/mpl/src/map_util.cpp
@@ -5,15 +5,6 @@
 namespace MPL {
 
 template <int Dim>
-int MapUtil<Dim>::getIndex(const Veci<Dim> &pn) {
-  if constexpr (Dim == 3) {
-    return pn(0) + dim_(0) * pn(1) + dim_(0) * dim_(1) * pn(2);
-  } else {
-    return pn(0) + dim_(0) * pn(1);
-  }
-}
-
-template <int Dim>
 bool MapUtil<Dim>::isOutside(const Veci<Dim> &pn) {
   for (int i = 0; i < Dim; i++)
     if (pn(i) < 0 || pn(i) >= dim_(i)) return true;
@@ -65,7 +56,7 @@ template <int Dim>
 Veci<Dim> MapUtil<Dim>::floatToInt(const Vecf<Dim> &pt) {
   Veci<Dim> pn;
   for (int i = 0; i < Dim; i++)
-    pn(i) = std::round((pt(i) - origin_d_(i)) / res_ - 0.5);
+    pn(i) = std::floor((pt(i) - origin_d_(i)) / res_);
   return pn;
 }
 


### PR DESCRIPTION
This PR addresses issue #35 I refactored the VoxelMapper class to use MapUtil since there were inconsistencies in the voxel alignment between the mapper and the planner. Both now use MapUtil which implements axis-aligned voxels. I added more unit tests for the various VoxelMapper class methods and I added some more comments in the source and header files. I also attached an image showing how there is a performance increase in the methods by changing the map data type. To achieve the performance increase I also had to change the iteration order along x-y-z to make it cache friendly given the new data type. In the image you can see, for example, that the getInflatedMap method takes about 71% less time to execute.
![benchmark](https://user-images.githubusercontent.com/33842080/178375397-fff252d3-a4a7-478f-945e-35a4fde09d6e.png)

Finally, I added some comments in the CMakelists.txt file in the mapper package indicating how to run the tests and the benchmarks. Google Benchmark is added to the mapper package when compiling via CMake's FetchContent module (it was not added directly in this repository).
