### PR TITLE
MapUtil Optimization

### DIFF
--- a/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
+++ b/autonomy_core/map_plan/mapper/test/test_voxel_mapper.cpp
@@ -10,34 +10,34 @@
  * @brief This function is passed as a parameter to the sort method so that
  * points in a point cloud can be sorted. Points are first compared by their
  * first axis and consequently compared through their next axis if the previous
- * are equal 
+ * are equal
  * @param first : first element to compare
  * @param second : second element to compare
  * @return returns true if the first parameter is smaller than the second
  * and false otherwise
  */
 bool comparePoints(Eigen::Vector3d first, Eigen::Vector3d second) {
-    const double epsilon = 0.000001;
+  const double epsilon = 0.000001;
 
-    if (fabs(first[0] - second[0]) < epsilon) {
-        // Index 0 is the same so check next index
-        if (fabs(first[1] - second[1]) < epsilon) {
-            // Index 1 is the same so check the last index
-            if (fabs(first[2] - second[2]) < epsilon) {
-                // All elements are equal
-                return false;
-            } else {
-                // Points differ at index 2 so compare them normally
-                return first[2] < second[2];
-            }
-        } else {
-            // Points differ at index 1 so compare them normally
-            return first[1] < second[1];
-        }
+  if (fabs(first[0] - second[0]) < epsilon) {
+    // Index 0 is the same so check next index
+    if (fabs(first[1] - second[1]) < epsilon) {
+      // Index 1 is the same so check the last index
+      if (fabs(first[2] - second[2]) < epsilon) {
+        // All elements are equal
+        return false;
+      } else {
+        // Points differ at index 2 so compare them normally
+        return first[2] < second[2];
+      }
     } else {
-        // They are not equal so compare them normally
-        return first[0] < second[0];
+      // Points differ at index 1 so compare them normally
+      return first[1] < second[1];
     }
+  } else {
+    // They are not equal so compare them normally
+    return first[0] < second[0];
+  }
 }
 
 
@@ -48,31 +48,31 @@ namespace mapper {
 /** Declaration of fixture class to use the same configuration across tests **/
 class VoxelMapperTest : public testing::Test {
  protected:
-    void SetUp() override;
-    Eigen::Vector3i getVoxel(int index);
+  void SetUp() override;
+  Eigen::Vector3i getVoxel(int index);
 
-    // The origin is the most negative corner
-    double x_origin_;
-    double y_origin_;
-    double z_origin_;
-    // Dimensions along each axis (NOT amount of voxels in each axis)
-    int x_dim_;
-    int y_dim_;
-    int z_dim_;
-    double resolution_;
-    int8_t val_default_;
-    int8_t val_occ_;
-    int8_t val_even_;
-    int8_t val_add_;
-    int8_t val_unknown_;
-    int8_t val_free_;
-    int8_t val_decay_;
-    int decay_times_;
+  // The origin is the most negative corner
+  double x_origin_;
+  double y_origin_;
+  double z_origin_;
+  // Dimensions along each axis (NOT amount of voxels in each axis)
+  int x_dim_;
+  int y_dim_;
+  int z_dim_;
+  double resolution_;
+  int8_t val_default_;
+  int8_t val_occ_;
+  int8_t val_even_;
+  int8_t val_add_;
+  int8_t val_unknown_;
+  int8_t val_free_;
+  int8_t val_decay_;
+  int decay_times_;
 
-    vec_Vec3d gt_cloud_;     // Ground truth point cloud for some tests
+  vec_Vec3d gt_cloud_;     // Ground truth point cloud for some tests
 
-    // This is the VoxelMapper object that is used for all the tests
-    std::unique_ptr<mapper::VoxelMapper> p_test_mapper_;
+  // This is the VoxelMapper object that is used for all the tests
+  std::unique_ptr<mapper::VoxelMapper> p_test_mapper_;
 };
 
 /**
@@ -82,54 +82,54 @@ class VoxelMapperTest : public testing::Test {
  * @return Eigen::Vector3i : Voxel index
  */
 Eigen::Vector3i VoxelMapperTest::getVoxel(int index) {
-    Eigen::Vector3i voxel;
-    int x_voxels = x_dim_ / resolution_;
-    int y_voxels = y_dim_ / resolution_;
-    voxel[2] = index / (x_voxels * y_voxels);
-    index = index % (x_voxels * y_voxels);
-    voxel[1] = index / x_voxels;
-    voxel[0] = index % x_voxels;
+  Eigen::Vector3i voxel;
+  int x_voxels = x_dim_ / resolution_;
+  int y_voxels = y_dim_ / resolution_;
+  voxel[2] = index / (x_voxels * y_voxels);
+  index = index % (x_voxels * y_voxels);
+  voxel[1] = index / x_voxels;
+  voxel[0] = index % x_voxels;
 
-    return voxel;
+  return voxel;
 }
 
 void VoxelMapperTest::SetUp() {
-    x_origin_ = -100;
-    y_origin_ = -100;
-    z_origin_ = -5;
-    x_dim_ = 200;
-    y_dim_ = 200;
-    z_dim_ = 10;
-    resolution_ = 0.5;
-    val_default_ = 0;
-    decay_times_ = 30;
-    Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
-    Eigen::Vector3d dimensions(x_dim_, y_dim_, z_dim_);
-    p_test_mapper_.reset( new mapper::VoxelMapper(origin, dimensions,
-                                                  resolution_, val_default_,
-                                                  decay_times_));
-    val_occ_        = p_test_mapper_->val_occ_;
-    val_even_       = p_test_mapper_->val_even_;
-    val_add_        = p_test_mapper_->val_add_;
-    val_unknown_    = p_test_mapper_->val_unknown_;
-    val_free_       = p_test_mapper_->val_free_;
-    val_decay_      = p_test_mapper_->val_decay_;
+  x_origin_ = -100;
+  y_origin_ = -100;
+  z_origin_ = -5;
+  x_dim_ = 200;
+  y_dim_ = 200;
+  z_dim_ = 10;
+  resolution_ = 0.5;
+  val_default_ = 0;
+  decay_times_ = 30;
+  Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
+  Eigen::Vector3d dimensions(x_dim_, y_dim_, z_dim_);
+  p_test_mapper_.reset( new mapper::VoxelMapper(origin, dimensions,
+                                                resolution_, val_default_,
+                                                decay_times_));
+  val_occ_        = p_test_mapper_->val_occ_;
+  val_even_       = p_test_mapper_->val_even_;
+  val_add_        = p_test_mapper_->val_add_;
+  val_unknown_    = p_test_mapper_->val_unknown_;
+  val_free_       = p_test_mapper_->val_free_;
+  val_decay_      = p_test_mapper_->val_decay_;
 
-    // Fill the cloud with some random known points
-    gt_cloud_.push_back(Eigen::Vector3d(0.25, 0.25, 0.25));
-    gt_cloud_.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
-    gt_cloud_.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
-    gt_cloud_.push_back(Eigen::Vector3d(20.25, 66.25, 4.25));
-    gt_cloud_.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
-    gt_cloud_.push_back(Eigen::Vector3d(85.25, -61.25, 2.25));
-    gt_cloud_.push_back(Eigen::Vector3d(94.25, -76.25, -3.25));
-    gt_cloud_.push_back(Eigen::Vector3d(-64.25, 58.25, -4.75));
-    gt_cloud_.push_back(Eigen::Vector3d(34.25, 34.25, -3.25));
-    gt_cloud_.push_back(Eigen::Vector3d(79.25, 12.25, -2.25));
+  // Fill the cloud with some random known points
+  gt_cloud_.push_back(Eigen::Vector3d(0.25, 0.25, 0.25));
+  gt_cloud_.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
+  gt_cloud_.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
+  gt_cloud_.push_back(Eigen::Vector3d(20.25, 66.25, 4.25));
+  gt_cloud_.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
+  gt_cloud_.push_back(Eigen::Vector3d(85.25, -61.25, 2.25));
+  gt_cloud_.push_back(Eigen::Vector3d(94.25, -76.25, -3.25));
+  gt_cloud_.push_back(Eigen::Vector3d(-64.25, 58.25, -4.75));
+  gt_cloud_.push_back(Eigen::Vector3d(34.25, 34.25, -3.25));
+  gt_cloud_.push_back(Eigen::Vector3d(79.25, 12.25, -2.25));
 
-    // Cloud is sorted because it should not matter in what order the points
-    // in point clouds returned by class methods
-    std::sort(gt_cloud_.begin(), gt_cloud_.end(), comparePoints);
+  // Cloud is sorted because it should not matter in what order the points
+  // in point clouds returned by class methods
+  std::sort(gt_cloud_.begin(), gt_cloud_.end(), comparePoints);
 }
 
 
@@ -146,28 +146,26 @@ void VoxelMapperTest::SetUp() {
  * assertions, we check that the map is created with the correct dimensions.
  */
 TEST_F(VoxelMapperTest, TestAllocateDimensions) {
-    // Creating voxel mapper object with same parameters as global_voxel_mapper
-    // in source file: local_global_mapper.cpp
-    Eigen::Vector3d origin(-100, -100, -5);
-    Eigen::Vector3d dimensions(200, 200, 10);
-    p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions,
-                                                 0.5, 0, 30));
-    EXPECT_EQ(p_test_mapper_->getMap().data.size(), 3200000);
+  // Creating voxel mapper object with same parameters as global_voxel_mapper
+  // in source file: local_global_mapper.cpp
+  Eigen::Vector3d origin(-100, -100, -5);
+  Eigen::Vector3d dimensions(200, 200, 10);
+  p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions, 0.5, 0, 30));
+  EXPECT_EQ(p_test_mapper_->getMap().data.size(), 3200000);
 
-    // Creating voxel mapper object with same parameters as storage_voxel_mapper
-    // in source file: local_global_mapper.cpp
-    origin = Eigen::Vector3d(-100, -100, -5);
-    dimensions = Eigen::Vector3d(200, 200, 12);
-    p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions,
-                                                 0.25, 0, 30));
-    EXPECT_EQ(p_test_mapper_->getMap().data.size(), 30720000);
+  // Creating voxel mapper object with same parameters as storage_voxel_mapper
+  // in source file: local_global_mapper.cpp
+  origin = Eigen::Vector3d(-100, -100, -5);
+  dimensions = Eigen::Vector3d(200, 200, 12);
+  p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions,
+                                                0.25, 0, 30));
+  EXPECT_EQ(p_test_mapper_->getMap().data.size(), 30720000);
 
-    // Creating voxel mapper object with custom parameters
-    origin = Eigen::Vector3d(-5, -5, -5);
-    dimensions = Eigen::Vector3d(10, 10, 10);
-    p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions,
-                                                 0.1, 0, 30));
-    EXPECT_EQ(p_test_mapper_->getMap().data.size(), 1000000);
+  // Creating voxel mapper object with custom parameters
+  origin = Eigen::Vector3d(-5, -5, -5);
+  dimensions = Eigen::Vector3d(10, 10, 10);
+  p_test_mapper_.reset(new mapper::VoxelMapper(origin, dimensions, 0.1, 0, 30));
+  EXPECT_EQ(p_test_mapper_->getMap().data.size(), 1000000);
 }
 
 /**
@@ -180,81 +178,81 @@ TEST_F(VoxelMapperTest, TestAllocateDimensions) {
  * should be kept as occupied and the new voxels should have the defualt value.
  */
 TEST_F(VoxelMapperTest, TestAllocateRelocate) {
-    // Relocating should not happen if origin and dimensions are the same as to
-    // what they previously were
-    Eigen::Vector3d prev_origin(x_origin_, y_origin_, z_origin_);
-    Eigen::Vector3d prev_dimensions(x_dim_, y_dim_, z_dim_);
-    ASSERT_FALSE(p_test_mapper_->allocate(prev_origin, prev_dimensions));
+  // Relocating should not happen if origin and dimensions are the same as to
+  // what they previously were
+  Eigen::Vector3d prev_origin(x_origin_, y_origin_, z_origin_);
+  Eigen::Vector3d prev_dimensions(x_dim_, y_dim_, z_dim_);
+  ASSERT_FALSE(p_test_mapper_->allocate(prev_origin, prev_dimensions));
 
-    // Mark all voxels as occupied. This original map, in world coordinates,
-    // ranges from:
-    // x: -100 to 100
-    // y: -100 to 100
-    // z: -5 to 5
-    // In voxels this translates to:
-    // x: 200 voxels from -100 to 0 and 200 voxels from 0 to 100
-    // y: 200 voxels from -100 to 0 and 200 voxels from 0 to 100
-    // z: 10 voxels from -5 to 0 and 10 voxels from 0 to 5
-    int num_voxels = 3200000;
-    std::vector<signed char> base_map(num_voxels, val_occ_);
-    Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
-    Eigen::Vector3i dimensions(x_dim_ / resolution_,
-                               y_dim_ / resolution_,
-                               z_dim_ / resolution_);
-    p_test_mapper_->setMap(origin, dimensions, base_map, resolution_);
+  // Mark all voxels as occupied. This original map, in world coordinates,
+  // ranges from:
+  // x: -100 to 100
+  // y: -100 to 100
+  // z: -5 to 5
+  // In voxels this translates to:
+  // x: 200 voxels from -100 to 0 and 200 voxels from 0 to 100
+  // y: 200 voxels from -100 to 0 and 200 voxels from 0 to 100
+  // z: 10 voxels from -5 to 0 and 10 voxels from 0 to 5
+  int num_voxels = 3200000;
+  std::vector<signed char> base_map(num_voxels, val_occ_);
+  Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
+  Eigen::Vector3i dimensions(x_dim_ / resolution_,
+                             y_dim_ / resolution_,
+                             z_dim_ / resolution_);
+  p_test_mapper_->setMap(origin, dimensions, base_map, resolution_);
 
-    // Relocating map in the positive direction in all three axes with its most
-    // negative corner at (0, 0, 0) and reducing x-dim and y-dim by 50. With the
-    // same resolution this means 100 less voxels in each dimension.
-    // z stays the same
-    Eigen::Vector3d new_origin(0, 0, 0);
-    Eigen::Vector3d new_dimensions(150, 150, 10);
-    // True means that the relocating actually happened
-    EXPECT_TRUE(p_test_mapper_->allocate(new_origin, new_dimensions));
+  // Relocating map in the positive direction in all three axes with its most
+  // negative corner at (0, 0, 0) and reducing x-dim and y-dim by 50. With the
+  // same resolution this means 100 less voxels in each dimension.
+  // z stays the same
+  Eigen::Vector3d new_origin(0, 0, 0);
+  Eigen::Vector3d new_dimensions(150, 150, 10);
+  // True means that the relocating actually happened
+  EXPECT_TRUE(p_test_mapper_->allocate(new_origin, new_dimensions));
 
-    planning_ros_msgs::VoxelMap relocated_map = p_test_mapper_->getMap();
+  planning_ros_msgs::VoxelMap relocated_map = p_test_mapper_->getMap();
 
-    // Create the ground truth voxel map to compare it to the relocated map
-    planning_ros_msgs::VoxelMap gt_voxel_map;
+  // Create the ground truth voxel map to compare it to the relocated map
+  planning_ros_msgs::VoxelMap gt_voxel_map;
 
-    // new map should have 300 voxels in x, 300 voxels in the y, and 20 in z
-    int dim_x = 150 / resolution_;
-    int dim_y = 150 / resolution_;
-    int dim_z = 10 / resolution_;
-    gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_default_);
+  // new map should have 300 voxels in x, 300 voxels in the y, and 20 in z
+  int dim_x = 150 / resolution_;
+  int dim_y = 150 / resolution_;
+  int dim_z = 10 / resolution_;
+  gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_default_);
 
-    // Sections with overlap between the previous origin-dimensions and the new
-    // origin-dimensions should be marked as obstacles while all other voxels
-    // should have the default value. In the relocated map, the dimensions range
-    // from
-    // x: 0 to 150
-    // y: 0 to 150
-    // z: 0 to 10
-    // Given the previous location and that all the voxels there were occupied,
-    // the new map has
-    // x: The first 200 voxels marked as occupied and the last 100 as default
-    // y: The first 200 voxels marked as occupied and the last 100 as default
-    // z: The first 10 voxels marked as occupied and the last 10 as default
-    // so set that for the ground truth voxel map
-    for (int x = 0 ; x < 200; x++) {
-        for (int y = 0; y < 200; y++) {
-            for (int z = 0; z < 10; z++) {
-                int idx = x + dim_x * y + dim_x * dim_y * z;
-                gt_voxel_map.data[idx] = val_occ_;
-            }
-        }
+  // Sections with overlap between the previous origin-dimensions and the new
+  // origin-dimensions should be marked as obstacles while all other voxels
+  // should have the default value. In the relocated map, the dimensions range
+  // from
+  // x: 0 to 150
+  // y: 0 to 150
+  // z: 0 to 10
+  // Given the previous location and that all the voxels there were occupied,
+  // the new map has
+  // x: The first 200 voxels marked as occupied and the last 100 as default
+  // y: The first 200 voxels marked as occupied and the last 100 as default
+  // z: The first 10 voxels marked as occupied and the last 10 as default
+  // so set that for the ground truth voxel map
+  for (int x = 0 ; x < 200; x++) {
+    for (int y = 0; y < 200; y++) {
+      for (int z = 0; z < 10; z++) {
+        int idx = x + dim_x * y + dim_x * dim_y * z;
+        gt_voxel_map.data[idx] = val_occ_;
+      }
     }
+  }
 
-    num_voxels = gt_voxel_map.data.size();
-    ASSERT_EQ(relocated_map.data.size(), gt_voxel_map.data.size());
+  num_voxels = gt_voxel_map.data.size();
+  ASSERT_EQ(relocated_map.data.size(), gt_voxel_map.data.size());
 
-    for (int idx = 0; idx < num_voxels; idx++) {
-        auto voxel = getVoxel(idx);
-        EXPECT_EQ(relocated_map.data[idx], gt_voxel_map.data[idx])
-            << "IDX:" << idx << "\t"
-            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
-            << "]" << std::endl;
-    }
+  for (int idx = 0; idx < num_voxels; idx++) {
+    auto voxel = getVoxel(idx);
+    EXPECT_EQ(relocated_map.data[idx], gt_voxel_map.data[idx])
+      << "IDX:" << idx << "\t"
+      << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+      << "]" << std::endl;
+  }
 }
 
 /**
@@ -262,16 +260,16 @@ TEST_F(VoxelMapperTest, TestAllocateRelocate) {
  * in the map and the inflated map are marked as unknown
  */
 TEST_F(VoxelMapperTest, TestSetMapUknown) {
-    p_test_mapper_->setMapUnknown();
-    planning_ros_msgs::VoxelMap vox_map = p_test_mapper_->getMap();
-    planning_ros_msgs::VoxelMap inflated_vox_map =
-                                    p_test_mapper_->getInflatedMap();
-    for (auto &voxel : vox_map.data) {
-        EXPECT_EQ(voxel, val_unknown_);
-    }
-    for (auto &voxel : inflated_vox_map.data) {
-        EXPECT_EQ(voxel, val_unknown_);
-    }
+  p_test_mapper_->setMapUnknown();
+  planning_ros_msgs::VoxelMap vox_map = p_test_mapper_->getMap();
+  planning_ros_msgs::VoxelMap inflated_vox_map =
+                                  p_test_mapper_->getInflatedMap();
+  for (auto &voxel : vox_map.data) {
+    EXPECT_EQ(voxel, val_unknown_);
+  }
+  for (auto &voxel : inflated_vox_map.data) {
+    EXPECT_EQ(voxel, val_unknown_);
+  }
 }
 
 /**
@@ -279,16 +277,16 @@ TEST_F(VoxelMapperTest, TestSetMapUknown) {
  * in the map and the inflated map are marked as free
  */
 TEST_F(VoxelMapperTest, TestSetMapFree) {
-    p_test_mapper_->setMapFree();
-    planning_ros_msgs::VoxelMap vox_map = p_test_mapper_->getMap();
-    planning_ros_msgs::VoxelMap inflated_vox_map =
-                                    p_test_mapper_->getInflatedMap();
-    for (auto &voxel : vox_map.data) {
-        EXPECT_EQ(voxel, val_free_);
-    }
-    for (auto &voxel : inflated_vox_map.data) {
-        EXPECT_EQ(voxel, val_free_);
-    }
+  p_test_mapper_->setMapFree();
+  planning_ros_msgs::VoxelMap vox_map = p_test_mapper_->getMap();
+  planning_ros_msgs::VoxelMap inflated_vox_map =
+                                  p_test_mapper_->getInflatedMap();
+  for (auto &voxel : vox_map.data) {
+    EXPECT_EQ(voxel, val_free_);
+  }
+  for (auto &voxel : inflated_vox_map.data) {
+    EXPECT_EQ(voxel, val_free_);
+  }
 }
 
 /**
@@ -303,58 +301,58 @@ TEST_F(VoxelMapperTest, TestSetMapFree) {
  * occupied 
  */
 TEST_F(VoxelMapperTest, TestDecayLocalCloud) {
-    // Compute how many times decayLocalCloud must be called to free the voxels
-    int num_calls = (static_cast<float>(val_occ_)
-                     - static_cast<float>(val_even_))
-                     / static_cast<float>(val_decay_);
+  // Compute how many times decayLocalCloud must be called to free the voxels
+  int num_calls = (static_cast<float>(val_occ_)
+                   - static_cast<float>(val_even_))
+                   / static_cast<float>(val_decay_);
 
-    // Mark all voxels in the map as occupied
-    int num_voxels = 3200000;
-    std::vector<signed char> base_map(num_voxels, val_occ_);
-    Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
-    Eigen::Vector3i dimensions(x_dim_ / resolution_,
-                               y_dim_ / resolution_,
-                               z_dim_ / resolution_);
-    p_test_mapper_->setMap(origin, dimensions, base_map, resolution_);
+  // Mark all voxels in the map as occupied
+  int num_voxels = 3200000;
+  std::vector<signed char> base_map(num_voxels, val_occ_);
+  Eigen::Vector3d origin(x_origin_, y_origin_, z_origin_);
+  Eigen::Vector3i dimensions(x_dim_ / resolution_,
+                             y_dim_ / resolution_,
+                             z_dim_ / resolution_);
+  p_test_mapper_->setMap(origin, dimensions, base_map, resolution_);
 
-    // Now decay the voxels that are in the range of 9.1 in all three axes
-    // around (0, 0, 0) in world coordinates. This corresponds to the lidar's
-    // position in the map's frame of reference
-    Eigen::Vector3d position(0, 0, 0);
-    double max_range = 9.1;
-    for (int i = 0; i < num_calls; i++) {
-        p_test_mapper_->decayLocalCloud(position, max_range);
+  // Now decay the voxels that are in the range of 9.1 in all three axes
+  // around (0, 0, 0) in world coordinates. This corresponds to the lidar's
+  // position in the map's frame of reference
+  Eigen::Vector3d position(0, 0, 0);
+  double max_range = 9.1;
+  for (int i = 0; i < num_calls; i++) {
+    p_test_mapper_->decayLocalCloud(position, max_range);
+  }
+
+  planning_ros_msgs::VoxelMap decayed_map = p_test_mapper_->getMap();
+
+  // Create the ground truth voxel map to compare it to the decayed map
+  planning_ros_msgs::VoxelMap gt_voxel_map;
+  int dim_x = x_dim_ / resolution_;
+  int dim_y = y_dim_ / resolution_;
+  int dim_z = z_dim_ / resolution_;
+  // All voxels should be marked occupied except the decayed voxel locations
+  gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_occ_);
+
+  // Free the voxels that should be decayed
+  for (int x = 181; x <= 218; x++) {
+    for (int y = 181; y <= 218; y++) {
+      for (int z = 0; z <= 19; z++) {
+        int idx = x + 400 * y + 400 * 400 * z;
+        gt_voxel_map.data[idx] = val_free_;
+      }
     }
+  }
 
-    planning_ros_msgs::VoxelMap decayed_map = p_test_mapper_->getMap();
-
-    // Create the ground truth voxel map to compare it to the decayed map
-    planning_ros_msgs::VoxelMap gt_voxel_map;
-    int dim_x = x_dim_ / resolution_;
-    int dim_y = y_dim_ / resolution_;
-    int dim_z = z_dim_ / resolution_;
-    // All voxels should be marked occupied except the decayed voxel locations
-    gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_occ_);
-
-    // Free the voxels that should be decayed
-    for (int x = 181; x <= 218; x++) {
-        for (int y = 181; y <= 218; y++) {
-            for (int z = 0; z <= 19; z++) {
-                int idx = x + 400 * y + 400 * 400 * z;
-                gt_voxel_map.data[idx] = val_free_;
-            }
-        }
-    }
-
-    // Finally make the comparison
-    ASSERT_EQ(decayed_map.data.size(), gt_voxel_map.data.size());
-    for (int idx = 0; idx < num_voxels; idx++) {
-        auto voxel = getVoxel(idx);
-        EXPECT_EQ(decayed_map.data[idx], gt_voxel_map.data[idx])
-            << "IDX:" << idx << "\t"
-            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
-            << "]" << std::endl;
-    }
+  // Finally make the comparison
+  ASSERT_EQ(decayed_map.data.size(), gt_voxel_map.data.size());
+  for (int idx = 0; idx < num_voxels; idx++) {
+    auto voxel = getVoxel(idx);
+    EXPECT_EQ(decayed_map.data[idx], gt_voxel_map.data[idx])
+      << "IDX:" << idx << "\t"
+      << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+      << "]" << std::endl;
+  }
 }
 
 /**
@@ -372,111 +370,109 @@ TEST_F(VoxelMapperTest, TestDecayLocalCloud) {
  * normal map and the inflated map to their ground truths.
  */
 TEST_F(VoxelMapperTest, TestAddCloud) {
-    // We will consider that the lidar is at position (-10, -5, -1) without any
-    // rotation in the map frame of reference
-    Eigen::Vector3d lidar_pos(-10, -5, -1);
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(lidar_pos) *
-                                  Eigen::AngleAxisd(0,
-                                                    Eigen::Vector3d(0, 0, 0));
-    double max_range = 3.0;
-    vec_Vec3d lidar_points;
+  // We will consider that the lidar is at position (-10, -5, -1) without any
+  // rotation in the map frame of reference
+  Eigen::Vector3d lidar_pos(-10, -5, -1);
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(lidar_pos) *
+                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  double max_range = 3.0;
+  vec_Vec3d lidar_points;
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for 20 voxels in the positive and negative
-    // direction along all 3 axes. Note that these points are with respect to
-    // the lidar frame which is at position (-10, -5, -1) in the world frame
-    for (int k = -20; k < 20; k++) {
-        double real_k = k * 0.5 + 0.25;
-        Eigen::Vector3d point_x(real_k, 0, 0);
-        Eigen::Vector3d point_y(0, real_k, 0);
-        Eigen::Vector3d point_z(0, 0, real_k);
-        for (int n = 0; n < num_points + 1; n++) {
-            lidar_points.push_back(point_x);
-            lidar_points.push_back(point_y);
-            lidar_points.push_back(point_z);
-        }
+  // Add num_points+1 points for 20 voxels in the positive and negative
+  // direction along all 3 axes. Note that these points are with respect to
+  // the lidar frame which is at position (-10, -5, -1) in the world frame
+  for (int k = -20; k < 20; k++) {
+    double real_k = k * 0.5 + 0.25;
+    Eigen::Vector3d point_x(real_k, 0, 0);
+    Eigen::Vector3d point_y(0, real_k, 0);
+    Eigen::Vector3d point_z(0, 0, real_k);
+    for (int n = 0; n < num_points + 1; n++) {
+      lidar_points.push_back(point_x);
+      lidar_points.push_back(point_y);
+      lidar_points.push_back(point_z);
     }
+  }
 
-    // Current neighboring voxels for global map are just +-1 in x and y
-    // directions, so replicate this for tests
-    vec_Vec3i neighbors;
-    neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
-    neighbors.push_back(Eigen::Vector3i(1, 0, 0));
-    neighbors.push_back(Eigen::Vector3i(0, -1, 0));
-    neighbors.push_back(Eigen::Vector3i(0, 1, 0));
+  // Current neighboring voxels for global map are just +-1 in x and y
+  // directions, so replicate this for tests
+  vec_Vec3i neighbors;
+  neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
+  neighbors.push_back(Eigen::Vector3i(1, 0, 0));
+  neighbors.push_back(Eigen::Vector3i(0, -1, 0));
+  neighbors.push_back(Eigen::Vector3i(0, 1, 0));
 
-    p_test_mapper_->addCloud(lidar_points, t_map_lidar, neighbors, false,
-                             max_range);
-    planning_ros_msgs::VoxelMap processed_map = p_test_mapper_->getMap();
-    planning_ros_msgs::VoxelMap processed_inflated_map;
-    processed_inflated_map = p_test_mapper_->getInflatedMap();
+  p_test_mapper_->addCloud(lidar_points, t_map_lidar, neighbors, false,
+                            max_range);
+  planning_ros_msgs::VoxelMap processed_map = p_test_mapper_->getMap();
+  planning_ros_msgs::VoxelMap processed_inflated_map;
+  processed_inflated_map = p_test_mapper_->getInflatedMap();
 
-    // Create the ground truth voxel maps to compare to the normal map and the
-    // inflated map
-    planning_ros_msgs::VoxelMap gt_voxel_map;
-    planning_ros_msgs::VoxelMap gt_inflated_voxel_map;
-    int x_dim = x_dim_ / resolution_;
-    int y_dim = y_dim_ / resolution_;
-    int z_dim = z_dim_ / resolution_;
-    gt_voxel_map.data.resize(x_dim * y_dim * z_dim, val_default_);
-    gt_inflated_voxel_map.data.resize(x_dim * y_dim * z_dim, val_default_);
+  // Create the ground truth voxel maps to compare to the normal map and the
+  // inflated map
+  planning_ros_msgs::VoxelMap gt_voxel_map;
+  planning_ros_msgs::VoxelMap gt_inflated_voxel_map;
+  int x_dim = x_dim_ / resolution_;
+  int y_dim = y_dim_ / resolution_;
+  int z_dim = z_dim_ / resolution_;
+  gt_voxel_map.data.resize(x_dim * y_dim * z_dim, val_default_);
+  gt_inflated_voxel_map.data.resize(x_dim * y_dim * z_dim, val_default_);
 
-    // Fill the voxels that should be occupied. To know which voxels should be
-    // occupied, consider the pose of the lidar and the max range of the points
-    // meaning some points should be filtered out. The lidar position
-    // (-10, -5, -1) lies at the most negative corners of voxels
-    // X: 180, Y: 190, Z: 8 and with a range of 3 for the points, that is 6
-    // voxels towards each direction
-    Eigen::Vector3i voxel_start(180, 190, 8);
-    std::vector<std::vector<int>> ranges{{174, 185}, {184, 195}, {2, 13}};
+  // Fill the voxels that should be occupied. To know which voxels should be
+  // occupied, consider the pose of the lidar and the max range of the points
+  // meaning some points should be filtered out. The lidar position
+  // (-10, -5, -1) lies at the most negative corners of voxels
+  // X: 180, Y: 190, Z: 8 and with a range of 3 for the points, that is 6
+  // voxels towards each direction
+  Eigen::Vector3i voxel_start(180, 190, 8);
+  std::vector<std::vector<int>> ranges{{174, 185}, {184, 195}, {2, 13}};
 
-    for (int i = 0; i < 3; i++) {
-        // While iterating through each range, keep the other two axes static
-        for (int k = ranges[i][0]; k <= ranges[i][1]; k++) {
-            int x = i == 0 ? k : voxel_start[0];
-            int y = i == 1 ? k : voxel_start[1];
-            int z = i == 2 ? k : voxel_start[2];
+  for (int i = 0; i < 3; i++) {
+    // While iterating through each range, keep the other two axes static
+    for (int k = ranges[i][0]; k <= ranges[i][1]; k++) {
+      int x = i == 0 ? k : voxel_start[0];
+      int y = i == 1 ? k : voxel_start[1];
+      int z = i == 2 ? k : voxel_start[2];
 
-            int idx = x + x_dim * y + x_dim * y_dim * z;
-            gt_voxel_map.data[idx] = val_occ_;
-            gt_inflated_voxel_map.data[idx] = val_occ_;
+      int idx = x + x_dim * y + x_dim * y_dim * z;
+      gt_voxel_map.data[idx] = val_occ_;
+      gt_inflated_voxel_map.data[idx] = val_occ_;
 
-            // Include neighbors for the inflated map
-            Eigen::Vector3i current_voxel(x, y, z);
-            for (auto &neighbor : neighbors) {
-                Eigen::Vector3i neighbor_voxel = current_voxel + neighbor;
-                int idx = neighbor_voxel(0) + x_dim * neighbor_voxel(1)
-                            + x_dim * y_dim * neighbor_voxel(2);
-                gt_inflated_voxel_map.data[idx] = val_occ_;
-            }
-        }
+      // Include neighbors for the inflated map
+      Eigen::Vector3i current_voxel(x, y, z);
+      for (auto &neighbor : neighbors) {
+        Eigen::Vector3i neighbor_voxel = current_voxel + neighbor;
+        int idx = neighbor_voxel(0) + x_dim * neighbor_voxel(1)
+                    + x_dim * y_dim * neighbor_voxel(2);
+        gt_inflated_voxel_map.data[idx] = val_occ_;
+      }
     }
+  }
 
-    // Compare normal map
-    int num_voxels = x_dim * y_dim * z_dim;
-    ASSERT_EQ(processed_map.data.size(), gt_voxel_map.data.size());
-    for (int idx = 0; idx < num_voxels; idx++) {
-        auto voxel = getVoxel(idx);
-        EXPECT_EQ(processed_map.data[idx], gt_voxel_map.data[idx])
-            << "IDX:" << idx << "\t"
-            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
-            << "]" << std::endl;
-    }
+  // Compare normal map
+  int num_voxels = x_dim * y_dim * z_dim;
+  ASSERT_EQ(processed_map.data.size(), gt_voxel_map.data.size());
+  for (int idx = 0; idx < num_voxels; idx++) {
+    auto voxel = getVoxel(idx);
+    EXPECT_EQ(processed_map.data[idx], gt_voxel_map.data[idx])
+      << "IDX:" << idx << "\t"
+      << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+      << "]" << std::endl;
+  }
 
-    // Compare the inflated map
-    ASSERT_EQ(processed_inflated_map.data.size(),
-              gt_inflated_voxel_map.data.size());
-    for (int idx = 0; idx < num_voxels; idx++) {
-        auto voxel = getVoxel(idx);
-        EXPECT_EQ(processed_inflated_map.data[idx],
-                  gt_inflated_voxel_map.data[idx])
-            << "IDX:" << idx << "\t"
-            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
-            << "]" << std::endl;
-    }
+  // Compare the inflated map
+  ASSERT_EQ(processed_inflated_map.data.size(),
+            gt_inflated_voxel_map.data.size());
+  for (int idx = 0; idx < num_voxels; idx++) {
+    auto voxel = getVoxel(idx);
+    EXPECT_EQ(processed_inflated_map.data[idx], gt_inflated_voxel_map.data[idx])
+      << "IDX:" << idx << "\t"
+      << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+      << "]" << std::endl;
+  }
 }
 
 /**
@@ -487,19 +483,19 @@ TEST_F(VoxelMapperTest, TestAddCloud) {
  * will just compare the maps to each other after being created.
  */
 TEST_F(VoxelMapperTest, TestGetInflatedMap) {
-    planning_ros_msgs::VoxelMap normal_map = p_test_mapper_->getMap();
-    planning_ros_msgs::VoxelMap inflated_map = p_test_mapper_->getInflatedMap();
+  planning_ros_msgs::VoxelMap normal_map = p_test_mapper_->getMap();
+  planning_ros_msgs::VoxelMap inflated_map = p_test_mapper_->getInflatedMap();
 
-    int num_voxels = 3200000;
-    ASSERT_EQ(normal_map.data.size(), num_voxels);
-    ASSERT_EQ(normal_map.data.size(), inflated_map.data.size());
-    for (int idx = 0; idx < num_voxels; idx++) {
-        auto voxel = getVoxel(idx);
-        EXPECT_EQ(normal_map.data[idx], inflated_map.data[idx])
-            << "IDX:" << idx << "\t"
-            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
-            << "]" << std::endl;
-    }
+  int num_voxels = 3200000;
+  ASSERT_EQ(normal_map.data.size(), num_voxels);
+  ASSERT_EQ(normal_map.data.size(), inflated_map.data.size());
+  for (int idx = 0; idx < num_voxels; idx++) {
+    auto voxel = getVoxel(idx);
+    EXPECT_EQ(normal_map.data[idx], inflated_map.data[idx])
+      << "IDX:" << idx << "\t"
+      << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+      << "]" << std::endl;
+  }
 }
 
 /**
@@ -514,42 +510,42 @@ TEST_F(VoxelMapperTest, TestGetInflatedMap) {
  * to the default value while all other voxels set to occupied.
  */
 TEST_F(VoxelMapperTest, TestGetInflatedLocalMap) {
-    // The origin of the local map is moved in the positive direction in all
-    // three axes by different amounts. This will cause a portion of the local
-    // map to overlap with the original map.
-    Eigen::Vector3d origin(75, 25, 2.5);    // Prev origin was (-100, -100, -5)
-    Eigen::Vector3d dimensions(100, 100, 10);   // Prev dimen was (200, 200, 10)
+  // The origin of the local map is moved in the positive direction in all
+  // three axes by different amounts. This will cause a portion of the local
+  // map to overlap with the original map.
+  Eigen::Vector3d origin(75, 25, 2.5);    // Prev origin was (-100, -100, -5)
+  Eigen::Vector3d dimensions(100, 100, 10);   // Prev dimen was (200, 200, 10)
 
-    planning_ros_msgs::VoxelMap local_map;
-    local_map = p_test_mapper_->getInflatedLocalMap(origin, dimensions);
+  planning_ros_msgs::VoxelMap local_map;
+  local_map = p_test_mapper_->getInflatedLocalMap(origin, dimensions);
 
-    // Create the ground truth voxel map to compare it to the local map
-    planning_ros_msgs::VoxelMap gt_voxel_map;
-    int dim_x = dimensions(0) / resolution_;
-    int dim_y = dimensions(1) / resolution_;
-    int dim_z = dimensions(2) / resolution_;
-    gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_occ_);
+  // Create the ground truth voxel map to compare it to the local map
+  planning_ros_msgs::VoxelMap gt_voxel_map;
+  int dim_x = dimensions(0) / resolution_;
+  int dim_y = dimensions(1) / resolution_;
+  int dim_z = dimensions(2) / resolution_;
+  gt_voxel_map.data.resize(dim_x * dim_y * dim_z, val_occ_);
 
-    // Set the overlapping voxels to the default value
-    for (int x = 0; x < 50; x++) {          // 200 - 150 = 50
-        for (int y = 0; y < 150; y++) {     // 200 - 50 = 150
-            for (int z = 0; z < 5; z++) {   // 10 - 5 = 5
-                int idx = x + dim_x * y + dim_x * dim_y * z;
-                gt_voxel_map.data[idx] = val_default_;
-            }
-        }
+  // Set the overlapping voxels to the default value
+  for (int x = 0; x < 50; x++) {          // 200 - 150 = 50
+    for (int y = 0; y < 150; y++) {       // 200 - 50 = 150
+      for (int z = 0; z < 5; z++) {       // 10 - 5 = 5
+        int idx = x + dim_x * y + dim_x * dim_y * z;
+        gt_voxel_map.data[idx] = val_default_;
+      }
     }
+  }
 
-    // Finally make the comparison
-    int num_voxels = dim_x * dim_y * dim_z;
-    ASSERT_EQ(local_map.data.size(), gt_voxel_map.data.size());
-    for (int idx = 0; idx < num_voxels; idx++) {
-        auto voxel = getVoxel(idx);
-        EXPECT_EQ(local_map.data[idx], gt_voxel_map.data[idx])
-            << "IDX:" << idx << "\t"
-            << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
-            << "]" << std::endl;
-    }
+  // Finally make the comparison
+  int num_voxels = dim_x * dim_y * dim_z;
+  ASSERT_EQ(local_map.data.size(), gt_voxel_map.data.size());
+  for (int idx = 0; idx < num_voxels; idx++) {
+    auto voxel = getVoxel(idx);
+    EXPECT_EQ(local_map.data[idx], gt_voxel_map.data[idx])
+      << "IDX:" << idx << "\t"
+      << "Voxel: [" << voxel[0] << ", " << voxel[1] << ", " << voxel[2]
+      << "]" << std::endl;
+  }
 }
 
 /**
@@ -558,42 +554,42 @@ TEST_F(VoxelMapperTest, TestGetInflatedLocalMap) {
  * center of the voxel should be included in the returned cloud.
  */
 TEST_F(VoxelMapperTest, TestGetCloud) {
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
-                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                              Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for all points in gt_cloud
-    vec_Vec3d scan_points;
-    for (auto &point : gt_cloud_) {
-        for (int n = 0; n < num_points + 1; n++) {
-            scan_points.push_back(point);
-        }
+  // Add num_points+1 points for all points in gt_cloud
+  vec_Vec3d scan_points;
+  for (auto &point : gt_cloud_) {
+    for (int n = 0; n < num_points + 1; n++) {
+      scan_points.push_back(point);
     }
+  }
 
-    // No neighboring voxels for inflated map, lidar pose is at the origin,
-    // no raytracing and the max range is large enough to avoid filtering out
-    // any point within the bounds of the map
-    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+  // No neighboring voxels for inflated map, lidar pose is at the origin,
+  // no raytracing and the max range is large enough to avoid filtering out
+  // any point within the bounds of the map
+  p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
 
-    vec_Vec3d point_cloud = p_test_mapper_->getCloud();
+  vec_Vec3d point_cloud = p_test_mapper_->getCloud();
 
-    // Sort the received point cloud to compare it to the ground truth point
-    // cloud. We sort because it should not matter in what order the points
-    // are received
-    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+  // Sort the received point cloud to compare it to the ground truth point
+  // cloud. We sort because it should not matter in what order the points
+  // are received
+  std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
 
-    ASSERT_EQ(point_cloud.size(), gt_cloud_.size());
-    // Iterate over every point
-    for (int i = 0; i < gt_cloud_.size(); i++) {
-        // iterate over every index in each point
-        for (int n = 0; n < 3; n++) {
-            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_cloud_[i][n])
-                << "IDX: " << i << ", Axis: " << n << std::endl;
-        }
+  ASSERT_EQ(point_cloud.size(), gt_cloud_.size());
+  // Iterate over every point
+  for (int i = 0; i < gt_cloud_.size(); i++) {
+    // iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_cloud_[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
     }
+  }
 }
 
 /**
@@ -602,42 +598,42 @@ TEST_F(VoxelMapperTest, TestGetCloud) {
  * center of the voxel should be included in the returned cloud.
  */
 TEST_F(VoxelMapperTest, TestGetInflatedCloud) {
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
-                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                              Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for all points in gt_cloud
-    vec_Vec3d scan_points;
-    for (auto &point : gt_cloud_) {
-        for (int n = 0; n < num_points + 1; n++) {
-            scan_points.push_back(point);
-        }
+  // Add num_points+1 points for all points in gt_cloud
+  vec_Vec3d scan_points;
+  for (auto &point : gt_cloud_) {
+    for (int n = 0; n < num_points + 1; n++) {
+      scan_points.push_back(point);
     }
+  }
 
-    // No neighboring voxels for inflated map, lidar pose is at the origin,
-    // no raytracing and the max range is large enough to avoid filtering out
-    // any point within the bounds of the map
-    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+  // No neighboring voxels for inflated map, lidar pose is at the origin,
+  // no raytracing and the max range is large enough to avoid filtering out
+  // any point within the bounds of the map
+  p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
 
-    vec_Vec3d point_cloud = p_test_mapper_->getInflatedCloud();
+  vec_Vec3d point_cloud = p_test_mapper_->getInflatedCloud();
 
-    // Sort the received point cloud to compare it to the ground truth point
-    // cloud. We sort because it should not matter in what order the points
-    // are received
-    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+  // Sort the received point cloud to compare it to the ground truth point
+  // cloud. We sort because it should not matter in what order the points
+  // are received
+  std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
 
-    ASSERT_EQ(point_cloud.size(), gt_cloud_.size());
-    // Iterate over every point
-    for (int i = 0; i < gt_cloud_.size(); i++) {
-        // iterate over every index in each point
-        for (int n = 0; n < 3; n++) {
-            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_cloud_[i][n])
-                << "IDX: " << i << ", Axis: " << n << std::endl;
-        }
+  ASSERT_EQ(point_cloud.size(), gt_cloud_.size());
+  // Iterate over every point
+  for (int i = 0; i < gt_cloud_.size(); i++) {
+    // iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_cloud_[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
     }
+  }
 }
 
 /**
@@ -649,108 +645,107 @@ TEST_F(VoxelMapperTest, TestGetInflatedCloud) {
  * should be returned when calling getLocalCloud.
  */
 TEST_F(VoxelMapperTest, TestGetLocalCloud) {
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
-                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                              Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for all points in gt_cloud
-    vec_Vec3d scan_points;
-    for (auto &point : gt_cloud_) {
-        for (int n = 0; n < num_points + 1; n++) {
-            scan_points.push_back(point);
-        }
+  // Add num_points+1 points for all points in gt_cloud
+  vec_Vec3d scan_points;
+  for (auto &point : gt_cloud_) {
+    for (int n = 0; n < num_points + 1; n++) {
+      scan_points.push_back(point);
     }
+  }
 
-    // No neighboring voxels for inflated map, lidar pose is at the origin,
-    // no raytracing and the max range is large enough to avoid filtering out
-    // any point within the bounds of the map
-    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+  // No neighboring voxels for inflated map, lidar pose is at the origin,
+  // no raytracing and the max range is large enough to avoid filtering out
+  // any point within the bounds of the map
+  p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
 
-    // Get points that are within the following bounds:
-    // Lower: [-35, -50, 1]
-    // Upper: [35, 25, 4.4]
-    Eigen::Vector3d origin(-35, -50, 1);
-    Eigen::Vector3d dimensions(70, 75, 3.4);
-    vec_Vec3d point_cloud =
-        p_test_mapper_->getLocalCloud(origin, dimensions);
+  // Get points that are within the following bounds:
+  // Lower: [-35, -50, 1]
+  // Upper: [35, 25, 4.4]
+  Eigen::Vector3d origin(-35, -50, 1);
+  Eigen::Vector3d dimensions(70, 75, 3.4);
+  vec_Vec3d point_cloud = p_test_mapper_->getLocalCloud(origin, dimensions);
 
-    // Create the local ground truth cloud
-    vec_Vec3d gt_local_cloud;
-    gt_local_cloud.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
-    gt_local_cloud.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
-    gt_local_cloud.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
+  // Create the local ground truth cloud
+  vec_Vec3d gt_local_cloud;
+  gt_local_cloud.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
+  gt_local_cloud.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
+  gt_local_cloud.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
 
-    // Sort the received point cloud to compare it to the ground truth point
-    // cloud. We sort because it should not matter in what order the points
-    // are received
-    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+  // Sort the received point cloud to compare it to the ground truth point
+  // cloud. We sort because it should not matter in what order the points
+  // are received
+  std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
 
-    ASSERT_EQ(point_cloud.size(), gt_local_cloud.size());
-    // Iterate over every point
-    for (int i = 0; i < gt_local_cloud.size(); i++) {
-        // iterate over every index in each point
-        for (int n = 0; n < 3; n++) {
-            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_local_cloud[i][n])
-                << "IDX: " << i << ", Axis: " << n << std::endl;
-        }
+  ASSERT_EQ(point_cloud.size(), gt_local_cloud.size());
+  // Iterate over every point
+  for (int i = 0; i < gt_local_cloud.size(); i++) {
+    // iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_local_cloud[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
     }
+  }
 }
 
 /**
  * @brief Same as TestGetLocalCloud, but for the inflated map
  */
 TEST_F(VoxelMapperTest, TestGetInflatedLocalCloud) {
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
-                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                              Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for all points in gt_cloud
-    vec_Vec3d scan_points;
-    for (auto &point : gt_cloud_) {
-        for (int n = 0; n < num_points + 1; n++) {
-            scan_points.push_back(point);
-        }
+  // Add num_points+1 points for all points in gt_cloud
+  vec_Vec3d scan_points;
+  for (auto &point : gt_cloud_) {
+    for (int n = 0; n < num_points + 1; n++) {
+      scan_points.push_back(point);
     }
+  }
 
-    // No neighboring voxels for inflated map, lidar pose is at the origin,
-    // no raytracing and the max range is large enough to avoid filtering out
-    // any point within the bounds of the map
-    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+  // No neighboring voxels for inflated map, lidar pose is at the origin,
+  // no raytracing and the max range is large enough to avoid filtering out
+  // any point within the bounds of the map
+  p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
 
-    // Get points that are within the following bounds:
-    // Lower: [-35, -50, 1]
-    // Upper: [35, 25, 4.4]
-    Eigen::Vector3d origin(-35, -50, 1);
-    Eigen::Vector3d dimensions(70, 75, 3.4);
-    vec_Vec3d point_cloud =
-        p_test_mapper_->getInflatedLocalCloud(origin, dimensions);
+  // Get points that are within the following bounds:
+  // Lower: [-35, -50, 1]
+  // Upper: [35, 25, 4.4]
+  Eigen::Vector3d origin(-35, -50, 1);
+  Eigen::Vector3d dimensions(70, 75, 3.4);
+  vec_Vec3d point_cloud =
+    p_test_mapper_->getInflatedLocalCloud(origin, dimensions);
 
-    // Create the local ground truth cloud
-    vec_Vec3d gt_local_cloud;
-    gt_local_cloud.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
-    gt_local_cloud.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
-    gt_local_cloud.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
+  // Create the local ground truth cloud
+  vec_Vec3d gt_local_cloud;
+  gt_local_cloud.push_back(Eigen::Vector3d(-28.25, -12.25, 3.25));
+  gt_local_cloud.push_back(Eigen::Vector3d(0.75, 0.75, 1.75));
+  gt_local_cloud.push_back(Eigen::Vector3d(20.25, -49.25, 4.25));
 
-    // Sort the received point cloud to compare it to the ground truth point
-    // cloud. We sort because it should not matter in what order the points
-    // are received
-    std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
+  // Sort the received point cloud to compare it to the ground truth point
+  // cloud. We sort because it should not matter in what order the points
+  // are received
+  std::sort(point_cloud.begin(), point_cloud.end(), comparePoints);
 
-    ASSERT_EQ(point_cloud.size(), gt_local_cloud.size());
-    // Iterate over every point
-    for (int i = 0; i < gt_local_cloud.size(); i++) {
-        // iterate over every index in each point
-        for (int n = 0; n < 3; n++) {
-            EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_local_cloud[i][n])
-                << "IDX: " << i << ", Axis: " << n << std::endl;
-        }
+  ASSERT_EQ(point_cloud.size(), gt_local_cloud.size());
+  // Iterate over every point
+  for (int i = 0; i < gt_local_cloud.size(); i++) {
+    // iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(point_cloud[i][n], gt_local_cloud[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
     }
+  }
 }
 
 /**
@@ -760,42 +755,42 @@ TEST_F(VoxelMapperTest, TestGetInflatedLocalCloud) {
  * Then we free it with the freeVoxels method and check if it was done correctly
  */
 TEST_F(VoxelMapperTest, TestFreeVoxels) {
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
-                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                              Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for all points in gt_cloud
-    vec_Vec3d scan_points;
-    for (int n = 0; n < num_points + 1; n++) {
-        scan_points.push_back(Eigen::Vector3d(15, 10, 2));
-    }
+  // Add num_points+1 points for all points in gt_cloud
+  vec_Vec3d scan_points;
+  for (int n = 0; n < num_points + 1; n++) {
+    scan_points.push_back(Eigen::Vector3d(15, 10, 2));
+  }
 
-    // Current neighboring voxels for global map are just +-1 in x and y
-    // directions, so replicate this for tests
-    vec_Vec3i neighbors;
-    neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
-    neighbors.push_back(Eigen::Vector3i(1, 0, 0));
-    neighbors.push_back(Eigen::Vector3i(0, -1, 0));
-    neighbors.push_back(Eigen::Vector3i(0, 1, 0));
+  // Current neighboring voxels for global map are just +-1 in x and y
+  // directions, so replicate this for tests
+  vec_Vec3i neighbors;
+  neighbors.push_back(Eigen::Vector3i(-1, 0, 0));
+  neighbors.push_back(Eigen::Vector3i(1, 0, 0));
+  neighbors.push_back(Eigen::Vector3i(0, -1, 0));
+  neighbors.push_back(Eigen::Vector3i(0, 1, 0));
 
-    p_test_mapper_->addCloud(scan_points, t_map_lidar, neighbors, false, 180);
+  p_test_mapper_->addCloud(scan_points, t_map_lidar, neighbors, false, 180);
 
-    // Make sure that 5 voxels were marked as occupied
-    ASSERT_EQ(p_test_mapper_->getCloud().size(), 1);
-    ASSERT_EQ(p_test_mapper_->getInflatedCloud().size(), 5);
+  // Make sure that 5 voxels were marked as occupied
+  ASSERT_EQ(p_test_mapper_->getCloud().size(), 1);
+  ASSERT_EQ(p_test_mapper_->getInflatedCloud().size(), 5);
 
-    // Now free the voxels
-    p_test_mapper_->freeVoxels(Eigen::Vector3d(15, 10, 2), neighbors);
+  // Now free the voxels
+  p_test_mapper_->freeVoxels(Eigen::Vector3d(15, 10, 2), neighbors);
 
-    // No voxels should be occupied now
-    ASSERT_EQ(p_test_mapper_->getCloud().size(), 0);
+  // No voxels should be occupied now
+  ASSERT_EQ(p_test_mapper_->getCloud().size(), 0);
 
-    // If the neighboring voxels in the map are free, then the same voxels in
-    // inflated map are not freed.
-    ASSERT_EQ(p_test_mapper_->getInflatedCloud().size(), 4);
+  // If the neighboring voxels in the map are free, then the same voxels in
+  // inflated map are not freed.
+  ASSERT_EQ(p_test_mapper_->getInflatedCloud().size(), 4);
 }
 
 /**
@@ -809,148 +804,62 @@ TEST_F(VoxelMapperTest, TestFreeVoxels) {
  * compare the results to.
  */
 TEST_F(VoxelMapperTest, TestgetInflatedOccMap) {
-    Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
-                                Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
+  Eigen::Affine3d t_map_lidar = Eigen::Translation3d(0, 0, 0) *
+                              Eigen::AngleAxisd(0, Eigen::Vector3d(0, 0, 0));
 
-    // There needs to be more than num_points points per voxel to have a single
-    // point cloud set the respective voxels occupied
-    int num_points = (val_occ_ - val_even_) / val_add_;
+  // There needs to be more than num_points points per voxel to have a single
+  // point cloud set the respective voxels occupied
+  int num_points = (val_occ_ - val_even_) / val_add_;
 
-    // Add num_points+1 points for all points in gt_cloud
-    vec_Vec3d scan_points;
-    for (auto &point : gt_cloud_) {
-        for (int n = 0; n < num_points + 1; n++) {
-            scan_points.push_back(point);
-        }
+  // Add num_points+1 points for all points in gt_cloud
+  vec_Vec3d scan_points;
+  for (auto &point : gt_cloud_) {
+    for (int n = 0; n < num_points + 1; n++) {
+      scan_points.push_back(point);
     }
+  }
 
-    // No neighboring voxels for inflated map, lidar pose is at the origin,
-    // no raytracing and the max range is large enough to avoid filtering out
-    // any point within the bounds of the map
-    p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
+  // No neighboring voxels for inflated map, lidar pose is at the origin,
+  // no raytracing and the max range is large enough to avoid filtering out
+  // any point within the bounds of the map
+  p_test_mapper_->addCloud(scan_points, t_map_lidar, vec_Vec3i(), false, 180);
 
-    // Should consider vertical space between [-1.0, 3.5]
-    planning_ros_msgs::VoxelMap sliced_map =\
-        p_test_mapper_->getInflatedOccMap(1.25, 2.25);
+  // Should consider vertical space between [-1.0, 3.5]
+  planning_ros_msgs::VoxelMap sliced_map =
+    p_test_mapper_->getInflatedOccMap(1.25, 2.25);
 
-    // Create the ground truth voxel map
-    planning_ros_msgs::VoxelMap gt_slice;
-    int x_dim = x_dim_ / resolution_;
-    int y_dim = y_dim_ / resolution_;
-    gt_slice.data.resize(x_dim * y_dim, val_free_);
+  // Create the ground truth voxel map
+  planning_ros_msgs::VoxelMap gt_slice;
+  int x_dim = x_dim_ / resolution_;
+  int y_dim = y_dim_ / resolution_;
+  gt_slice.data.resize(x_dim * y_dim, val_free_);
 
-    // The points occupying a voxel in the previous vertical space are:
-    // (0.25, 0.25, 0.25)       -> voxel indices: [200, 200, 10]
-    // (0.75, 0.75, 1.75)       -> voxel indices: [201, 201, 13]
-    // (-28.25, -12.25, 3.25)   -> voxel indices: [143, 175, 16]
-    // (85.25, -61.25, 2.25)    -> voxel indices: [370, 77, 14]
-    // The returned voxel map uses column-major storage and we also have to
-    // consider axis aligned voxels, so the occupied pixels are computed as
-    // follows: x + x_dim * y, where x and y are the integer indices
-    std::vector<int> indices {80200, 80601, 70143, 31170};
-    for (auto &idx : indices) {
-        gt_slice.data[idx] = val_occ_;
-    }
+  // The points occupying a voxel in the previous vertical space are:
+  // (0.25, 0.25, 0.25)       -> voxel indices: [200, 200, 10]
+  // (0.75, 0.75, 1.75)       -> voxel indices: [201, 201, 13]
+  // (-28.25, -12.25, 3.25)   -> voxel indices: [143, 175, 16]
+  // (85.25, -61.25, 2.25)    -> voxel indices: [370, 77, 14]
+  // The returned voxel map uses column-major storage and we also have to
+  // consider axis aligned voxels, so the occupied pixels are computed as
+  // follows: x + x_dim * y, where x and y are the integer indices
+  std::vector<int> indices {80200, 80601, 70143, 31170};
+  for (auto &idx : indices) {
+    gt_slice.data[idx] = val_occ_;
+  }
 
-    // Finally compare the two slices
-    ASSERT_EQ(gt_slice.data.size(), sliced_map.data.size());
+  // Finally compare the two slices
+  ASSERT_EQ(gt_slice.data.size(), sliced_map.data.size());
 
-    for (int i = 0; i < gt_slice.data.size(); i++) {
-        EXPECT_EQ(gt_slice.data[i], sliced_map.data[i]) << std::endl;
-    }
+  for (int i = 0; i < gt_slice.data.size(); i++) {
+    EXPECT_EQ(gt_slice.data[i], sliced_map.data[i]) << std::endl;
+  }
 }
 
 }   // namespace mapper
 
 
-namespace MPL {
-
-/**
- * @brief map_util considers voxels to be axis-aligned. In this test we make
- * sure that the conversion from world coordinates to voxel indices and
- * vice-versa are reciprocal and consistent. We check the use of the
- * floatToInt and intToFloat functions.
- */
-TEST(MapUtilTesting, TestVoxelIndexing) {
-    // Create map_util object
-    VoxelMapUtil test_map;
-    // Dimensions are the amount of voxels in each axis
-    test_map.setMap(Vec3f(-100, -100, -5), Vec3i(400, 400, 20), {}, 0.5);
-
-    // Initialize set of points for converstion
-    vec_Vec3f point_cloud;      // Test point cloud
-    vec_Vec3f gt_point_cloud;   // Values that should be returned by intToFloat
-    vec_Vec3i voxel_indices;    // Values that should be returned by floatToInt
-
-    // Test most negative limit of the world
-    point_cloud.push_back(Eigen::Vector3d(-100, -100, -5));
-    gt_point_cloud.push_back(Eigen::Vector3d(-99.75, -99.75, -4.75));
-    voxel_indices.push_back(Eigen::Vector3i(0, 0, 0));
-
-    // Test most positive limit of the world
-    point_cloud.push_back(Eigen::Vector3d(100, 100, 5));
-    gt_point_cloud.push_back(Eigen::Vector3d(100.25, 100.25, 5.25));
-    voxel_indices.push_back(Eigen::Vector3i(400, 400, 20));
-
-    // Test outside the bounds of the world in the positive direction
-    point_cloud.push_back(Eigen::Vector3d(105, 105, 10));
-    gt_point_cloud.push_back(Eigen::Vector3d(105.25, 105.25, 10.25));
-    voxel_indices.push_back(Eigen::Vector3i(410, 410, 30));
-
-    // Test outside the bounds of the world in the most negative direction
-    point_cloud.push_back(Eigen::Vector3d(-105, -105, -10));
-    gt_point_cloud.push_back(Eigen::Vector3d(-104.75, -104.75, -9.75));
-    voxel_indices.push_back(Eigen::Vector3i(-10, -10, -10));
-
-    point_cloud.push_back(Eigen::Vector3d(-100.1, -100.6, -4.9));
-    gt_point_cloud.push_back(Eigen::Vector3d(-100.25, -100.75, -4.75));
-    voxel_indices.push_back(Eigen::Vector3i(-1, -2, 0));
-
-    // Check points near the voxel boundaries to make sure that voxels are
-    // actually axis-aligned and not origin-centered
-    point_cloud.push_back(Eigen::Vector3d(10.1, 10.1, 2));
-    gt_point_cloud.push_back(Eigen::Vector3d(10.25, 10.25, 2.25));
-    voxel_indices.push_back(Eigen::Vector3i(220, 220, 14));
-
-    point_cloud.push_back(Eigen::Vector3d(10.9, 10.9, 2));
-    gt_point_cloud.push_back(Eigen::Vector3d(10.75, 10.75, 2.25));
-    voxel_indices.push_back(Eigen::Vector3i(221, 221, 14));
-
-    point_cloud.push_back(Eigen::Vector3d(5.6, 5.6, 3));
-    gt_point_cloud.push_back(Eigen::Vector3d(5.75, 5.75, 3.25));
-    voxel_indices.push_back(Eigen::Vector3i(211, 211, 16));
-
-    point_cloud.push_back(Eigen::Vector3d(5.4, 5.4, 3));
-    gt_point_cloud.push_back(Eigen::Vector3d(5.25, 5.25, 3.25));
-    voxel_indices.push_back(Eigen::Vector3i(210, 210, 16));
-
-    for (int i = 0; i < point_cloud.size(); i++) {
-        auto &point = point_cloud[i];
-        auto &gt_point = gt_point_cloud[i];
-        auto &voxel = voxel_indices[i];
-        Eigen::Vector3i ret_indices = test_map.floatToInt(point);
-        Eigen::Vector3d ret_point = test_map.intToFloat(ret_indices);
-
-        // Compare the returned indices to the actual voxel indices
-        for (int n = 0; n < 3; n++) {
-            EXPECT_EQ(voxel[n], ret_indices[n]) << "Point idx: " << i
-                << "  Voxel: [" << voxel[0] << ", " << voxel[1] << ", "
-                << voxel[2] << "]" << std::endl;
-        }
-
-        // Compare the original point to the returned point
-        for (int n = 0; n < 3; n++) {
-            EXPECT_DOUBLE_EQ(gt_point[n], ret_point[n]) << "Point idx: " << i
-                << "  Point: [" << point[0] << ", " << point[1] << ", "
-                << point[2] << "]" << std::endl;
-        }
-    }
-}
-
-}   // namespace MPL
-
 int main(int argc, char **argv) {
-    testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }
 

--- a/autonomy_core/map_plan/mpl/CMakeLists.txt
+++ b/autonomy_core/map_plan/mpl/CMakeLists.txt
@@ -30,3 +30,38 @@ add_library(
   src/graph_search.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC include ${catkin_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen Boost::boost)
+
+#----------------------------------------------------------------------------------
+# Add testing with GoogleTest
+
+# To run test:
+#   catkin test motion_primitive_library
+enable_testing()
+
+catkin_add_gtest(test_map_util test/test_map_util.cpp)
+target_link_libraries(test_map_util ${catkin_LIBRARIES} ${PROJECT_NAME})
+
+#----------------------------------------------------------------------------------
+# Add microbenchmarking with Google Benchmark
+
+# To run benchmark:
+#   rosrun motion_primitive_library map_util_benchmarking
+# if you want to save the results to a file:
+#   rosrun motion_primitive_library map_util benchmarking --benchmark_out=file_name.json
+# if you want to compare two benchmark files, use the compare.py script located
+# in the build directory under motion_primitive_library/_deps/benchmark-src/tools/
+# (you will need to have pandas installed). Also changed the shebang to use python3
+# e.g. from the catkin root directory run:
+#   ./build/motion_primitive_library/_deps/benchmark-src/tools/compare.py benchmarks file1.json file2.json
+
+include(FetchContent)
+FetchContent_Declare(
+    benchmark
+    URL https://github.com/google/benchmark/archive/b7afda2cd2d81230737caa1073e160b6406798d7.zip
+)
+FetchContent_MakeAvailable(benchmark)
+
+add_executable(map_util_benchmarking test/benchmark_map_util.cpp)
+target_link_libraries(map_util_benchmarking benchmark::benchmark ${PROJECT_NAME})
+
+

--- a/autonomy_core/map_plan/mpl/include/mpl_collision/map_util.h
+++ b/autonomy_core/map_plan/mpl/include/mpl_collision/map_util.h
@@ -2,6 +2,7 @@
 
 #include "mpl_basis/data_type.h"
 #include <planning_ros_msgs/VoxelMap.h>
+#include <vector>
 
 namespace MPL {
 
@@ -104,12 +105,51 @@ typedef MapUtil<2> OccMapUtil;
 typedef MapUtil<3> VoxelMapUtil;
 
 template <int Dim>
-int MapUtil<Dim>::getIndex(const Veci<Dim> &pn) {
+inline int MapUtil<Dim>::getIndex(const Veci<Dim> &pn) {
   if constexpr (Dim == 3) {
     return pn(0) + dim_(0) * pn(1) + dim_(0) * dim_(1) * pn(2);
   } else {
     return pn(0) + dim_(0) * pn(1);
   }
+}
+
+template <int Dim>
+inline bool MapUtil<Dim>::isOutside(const Veci<Dim> &pn) {
+  if constexpr (Dim == 3) {
+    return (pn(0) < 0 || pn(0) >= dim_(0) ||
+            pn(1) < 0 || pn(1) >= dim_(1) ||
+            pn(2) < 0 || pn(2) >= dim_(2));
+  } else {
+    return (pn(0) < 0 || pn(0) >= dim_(0) ||
+            pn(1) < 0 || pn(1) >= dim_(1));
+  }
+}
+
+template <int Dim>
+inline bool MapUtil<Dim>::isFree(const Veci<Dim> &pn) {
+  // First check if the voxel is within the bounds of the map and if it isn't,
+  // return false. This is accomplished by taking advantage of short-circuit
+  // evaluation. An if-else statement could also be used here but it isn't
+  // to avoid issues with branch predictions and inline.
+  return (!isOutside(pn) && isFree(getIndex(pn)));
+}
+
+template <int Dim>
+inline bool MapUtil<Dim>::isOccupied(const Veci<Dim> &pn) {
+  // First check if the voxel is within the bounds of the map and if it isn't,
+  // return false. This is accomplished by taking advantage of short-circuit
+  // evaluation. An if-else statement could also be used here but it isn't
+  // to avoid issues with branch predictions and inline.
+  return (!isOutside(pn) && isOccupied(getIndex(pn)));
+}
+
+template <int Dim>
+inline bool MapUtil<Dim>::isUnknown(const Veci<Dim> &pn) {
+  // First check if the voxel is within the bounds of the map and if it isn't,
+  // return false. This is accomplished by taking advantage of short-circuit
+  // evaluation. An if-else statement could also be used here but it isn't
+  // to avoid issues with branch predictions and inline.
+  return (!isOutside(pn) && isUnknown(getIndex(pn)));
 }
 
 }  // namespace MPL

--- a/autonomy_core/map_plan/mpl/src/map_util.cpp
+++ b/autonomy_core/map_plan/mpl/src/map_util.cpp
@@ -5,35 +5,6 @@
 namespace MPL {
 
 template <int Dim>
-bool MapUtil<Dim>::isOutside(const Veci<Dim> &pn) {
-  for (int i = 0; i < Dim; i++)
-    if (pn(i) < 0 || pn(i) >= dim_(i)) return true;
-  return false;
-}
-
-template <int Dim>
-bool MapUtil<Dim>::isFree(const Veci<Dim> &pn) {
-  if (isOutside(pn))
-    return false;
-  else
-    return isFree(getIndex(pn));
-}
-
-template <int Dim>
-bool MapUtil<Dim>::isOccupied(const Veci<Dim> &pn) {
-  if (isOutside(pn))
-    return false;
-  else
-    return isOccupied(getIndex(pn));
-}
-
-template <int Dim>
-bool MapUtil<Dim>::isUnknown(const Veci<Dim> &pn) {
-  if (isOutside(pn)) return false;
-  return isUnknown(getIndex(pn));
-}
-
-template <int Dim>
 void MapUtil<Dim>::setMap(const Vecf<Dim> &ori, const Veci<Dim> &dim,
                           const Tmap &map, decimal_t res) {
   map_ = map;
@@ -93,16 +64,16 @@ vec_Vecf<Dim> MapUtil<Dim>::getCloud() {
   vec_Vecf<Dim> cloud;
   Veci<Dim> n;
   if constexpr (Dim == 3) {
-    for (n(0) = 0; n(0) < dim_(0); n(0)++) {
+    for (n(2) = 0; n(2) < dim_(2); n(2)++) {
       for (n(1) = 0; n(1) < dim_(1); n(1)++) {
-        for (n(2) = 0; n(2) < dim_(2); n(2)++) {
+        for (n(0) = 0; n(0) < dim_(0); n(0)++) {
           if (isOccupied(getIndex(n))) cloud.push_back(intToFloat(n));
         }
       }
     }
   } else {
-    for (n(0) = 0; n(0) < dim_(0); n(0)++) {
-      for (n(1) = 0; n(1) < dim_(1); n(1)++) {
+    for (n(1) = 0; n(1) < dim_(1); n(1)++) {
+      for (n(0) = 0; n(0) < dim_(0); n(0)++) {
         if (isOccupied(getIndex(n))) cloud.push_back(intToFloat(n));
       }
     }
@@ -116,16 +87,16 @@ vec_Vecf<Dim> MapUtil<Dim>::getFreeCloud() {
   Veci<Dim> n;
 
   if constexpr (Dim == 3) {
-    for (n(0) = 0; n(0) < dim_(0); n(0)++) {
+    for (n(2) = 0; n(2) < dim_(2); n(2)++) {
       for (n(1) = 0; n(1) < dim_(1); n(1)++) {
-        for (n(2) = 0; n(2) < dim_(2); n(2)++) {
+        for (n(0) = 0; n(0) < dim_(0); n(0)++) {
           if (isFree(getIndex(n))) cloud.push_back(intToFloat(n));
         }
       }
     }
   } else {
-    for (n(0) = 0; n(0) < dim_(0); n(0)++) {
-      for (n(1) = 0; n(1) < dim_(1); n(1)++) {
+    for (n(1) = 0; n(1) < dim_(1); n(1)++) {
+      for (n(0) = 0; n(0) < dim_(0); n(0)++) {
         if (isFree(getIndex(n))) cloud.push_back(intToFloat(n));
       }
     }
@@ -139,16 +110,16 @@ vec_Vecf<Dim> MapUtil<Dim>::getUnknownCloud() {
   Veci<Dim> n;
 
   if constexpr (Dim == 3) {
-    for (n(0) = 0; n(0) < dim_(0); n(0)++) {
+    for (n(2) = 0; n(2) < dim_(2); n(2)++) {
       for (n(1) = 0; n(1) < dim_(1); n(1)++) {
-        for (n(2) = 0; n(2) < dim_(2); n(2)++) {
+        for (n(0) = 0; n(0) < dim_(0); n(0)++) {
           if (isUnknown(getIndex(n))) cloud.push_back(intToFloat(n));
         }
       }
     }
   } else {
-    for (n(0) = 0; n(0) < dim_(0); n(0)++) {
-      for (n(1) = 0; n(1) < dim_(1); n(1)++) {
+    for (n(1) = 0; n(1) < dim_(1); n(1)++) {
+      for (n(0) = 0; n(0) < dim_(0); n(0)++) {
         if (isUnknown(getIndex(n))) cloud.push_back(intToFloat(n));
       }
     }

--- a/autonomy_core/map_plan/mpl/test/benchmark_map_util.cpp
+++ b/autonomy_core/map_plan/mpl/test/benchmark_map_util.cpp
@@ -69,7 +69,7 @@ BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isOutside)(benchmark::State& state) {
     // being optimized out
     int counter = 0;
 
-    for (auto &voxel: test_voxels_) {
+    for (auto &voxel : test_voxels_) {
       bool it_is = mapper_.isOutside(voxel);
 
       if (it_is) {
@@ -89,7 +89,7 @@ BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isFree)(benchmark::State& state) {
     // being optimized out
     int counter = 0;
 
-    for (auto &voxel: test_voxels_) {
+    for (auto &voxel : test_voxels_) {
       bool it_is = mapper_.isFree(voxel);
 
       if (it_is) {
@@ -109,7 +109,7 @@ BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isOccupied)(benchmark::State& state) {
     // being optimized out
     int counter = 0;
 
-    for (auto &voxel: test_voxels_) {
+    for (auto &voxel : test_voxels_) {
       bool it_is = mapper_.isOccupied(voxel);
 
       if (it_is) {
@@ -129,7 +129,7 @@ BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isUnknown)(benchmark::State& state) {
     // being optimized out
     int counter = 0;
 
-    for (auto &voxel: test_voxels_) {
+    for (auto &voxel : test_voxels_) {
       bool it_is = mapper_.isUnknown(voxel);
 
       if (it_is) {
@@ -187,7 +187,7 @@ BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_rayTrace)(benchmark::State& state) {
     for (auto &start : start_positions) {
       for (auto &end : end_positions) {
         vec_Vec3i voxels = mapper_.rayTrace(start, end);
-        if (voxels.size() == -1 ) {
+        if (voxels.size() == -1) {
           std::cout << "This message should not have been printed" << std::endl;
         }
       }

--- a/autonomy_core/map_plan/mpl/test/benchmark_map_util.cpp
+++ b/autonomy_core/map_plan/mpl/test/benchmark_map_util.cpp
@@ -1,0 +1,230 @@
+#include <benchmark/benchmark.h>
+#include <mpl_collision/map_util.h>
+
+// Create a fixture to share the same setup among all benchmarking tests
+class BenchmarkMapUtil : public benchmark::Fixture {
+ public:
+  void SetUp(const ::benchmark::State& state) {
+    Vec3f origin(-100, -100, -5);
+    Vec3i dim(400, 400, 20);
+    double resolution = 0.5;
+
+    // Initialize the map with val_free as the default value
+    std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                      planning_ros_msgs::VoxelMap::val_free);
+
+    /* Modify the values of some voxels to not have a uniform map */
+
+    // First set a region of voxels to be occupied in the center of the map.
+    for (int z = 5; z < 15; z++) {
+      for (int y = 25; y < 375; y++) {
+        for (int x = 25; x < 375; x++) {
+          int idx = x + dim(0) * y + dim(0) * dim(1) * z;
+          base_map[idx] = planning_ros_msgs::VoxelMap::val_occ;
+        }
+      }
+    }
+
+    // Then set a smaller region of voxels inside the previous region as unknown
+    for (int z = 7; z < 13; z++) {
+      for (int y = 75; y < 325; y++) {
+        for (int x = 75; x < 325; x++) {
+          int idx = x + dim(0) * y + dim(0) * dim(1) * z;
+          base_map[idx] = planning_ros_msgs::VoxelMap::val_unknown;
+        }
+      }
+    }
+
+    // Initialize the MapUtil object with the previously created map
+    mapper_.setMap(origin, dim, base_map, resolution);
+
+    /** Now populate the vectors of points and voxels. The amount of points
+     * should correspond to the amount of voxels. There should be some points
+     * that lie outside the bounds of the map as well to make sure that the
+     * isOutside function is used.
+     */
+
+    for (int x = -50; x < 450; x++) {
+      for (int y = -50; y < 450; y++) {
+        for (int z = -10; z < 30; z++) {
+          test_voxels_.push_back(Vec3i(x, y, z));
+          double real_x = x * 0.5 + 0.25;
+          double real_y = y * 0.5 + 0.25;
+          double real_z = z * 0.5 + 0.25;
+          test_cloud_.push_back(Vec3f(real_x, real_y, real_z));
+        }
+      }
+    }
+  }
+
+  MPL::VoxelMapUtil mapper_;
+  vec_Vec3i test_voxels_;
+  vec_Vec3f test_cloud_;
+};
+
+// Define benchmarks
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isOutside)(benchmark::State& state) {
+  for (auto _ : state) {
+    // Counter is used to add some dummy code to avoid the function call from
+    // being optimized out
+    int counter = 0;
+
+    for (auto &voxel: test_voxels_) {
+      bool it_is = mapper_.isOutside(voxel);
+
+      if (it_is) {
+        counter++;
+      }
+    }
+
+    if (counter == 0) {
+      std::cout << "This should not have been printed" << std::endl;
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isFree)(benchmark::State& state) {
+  for (auto _ : state) {
+    // Counter is used to add some dummy code to avoid the function call from
+    // being optimized out
+    int counter = 0;
+
+    for (auto &voxel: test_voxels_) {
+      bool it_is = mapper_.isFree(voxel);
+
+      if (it_is) {
+        counter++;
+      }
+    }
+
+    if (counter == 0) {
+      std::cout << "This should not have been printed" << std::endl;
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isOccupied)(benchmark::State& state) {
+  for (auto _ : state) {
+    // Counter is used to add some dummy code to avoid the function call from
+    // being optimized out
+    int counter = 0;
+
+    for (auto &voxel: test_voxels_) {
+      bool it_is = mapper_.isOccupied(voxel);
+
+      if (it_is) {
+        counter++;
+      }
+    }
+
+    if (counter == 0) {
+      std::cout << "This should not have been printed" << std::endl;
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_isUnknown)(benchmark::State& state) {
+  for (auto _ : state) {
+    // Counter is used to add some dummy code to avoid the function call from
+    // being optimized out
+    int counter = 0;
+
+    for (auto &voxel: test_voxels_) {
+      bool it_is = mapper_.isUnknown(voxel);
+
+      if (it_is) {
+        counter++;
+      }
+    }
+
+    if (counter == 0) {
+      std::cout << "This should not have been printed" << std::endl;
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_floatToInt)(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto &point : test_cloud_) {
+      Vec3i index = mapper_.floatToInt(point);
+
+      // Add some dummy conditional to avoid the function call from being
+      // optimized out
+      if (index(0) == -100000 && index(1) == -100000 && index(2) == -100000) {
+        std::cout << "This should not have been printed" << std::endl;
+      }
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_intToFloat)(benchmark::State& state) {
+  for (auto _ : state) {
+    for (auto &voxel : test_voxels_) {
+      Vec3f point = mapper_.intToFloat(voxel);
+
+      // Add some dummy conditional to avoid the function call from being
+      // optimized out
+      if (point(0) == -500 && point(1) == -500 && point(2) == -500) {
+        std::cout << "This should not have been printed" << std::endl;
+      }
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_rayTrace)(benchmark::State& state) {
+  vec_Vec3f start_positions;
+  vec_Vec3f end_positions;
+
+  start_positions.push_back(Vec3f(99, 77, 4));
+  start_positions.push_back(Vec3f(-80, 20, 1));
+  start_positions.push_back(Vec3f(-50, -50, 4));
+
+  end_positions.push_back(Vec3f(50, 50, 4));
+  end_positions.push_back(Vec3f(69, 18, -4));
+  end_positions.push_back(Vec3f(-10, 99, 3));
+
+  for (auto _ : state) {
+    for (auto &start : start_positions) {
+      for (auto &end : end_positions) {
+        vec_Vec3i voxels = mapper_.rayTrace(start, end);
+        if (voxels.size() == -1 ) {
+          std::cout << "This message should not have been printed" << std::endl;
+        }
+      }
+    }
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_getCloud)(benchmark::State& state) {
+  for (auto _ : state) {
+    vec_Vec3f cloud = mapper_.getCloud();
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_getFreeCloud)(benchmark::State& state) {
+  for (auto _ : state) {
+    vec_Vec3f cloud = mapper_.getFreeCloud();
+  }
+}
+
+BENCHMARK_DEFINE_F(BenchmarkMapUtil, BM_getUnknown)(benchmark::State& state) {
+  for (auto _ : state) {
+    vec_Vec3f cloud = mapper_.getUnknownCloud();
+  }
+}
+
+// Register Benchmarks
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_isOutside);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_isFree);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_isOccupied);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_isUnknown);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_floatToInt);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_intToFloat);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_rayTrace);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_getCloud);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_getFreeCloud);
+BENCHMARK_REGISTER_F(BenchmarkMapUtil, BM_getUnknown);
+
+BENCHMARK_MAIN();
+
+

--- a/autonomy_core/map_plan/mpl/test/test_map_util.cpp
+++ b/autonomy_core/map_plan/mpl/test/test_map_util.cpp
@@ -1,0 +1,540 @@
+#include <gtest/gtest.h>
+#include <planning_ros_msgs/VoxelMap.h>
+#include <iostream>
+#include <cmath>
+#include "mpl_collision/map_util.h"
+
+/**
+ * @brief This function is passed as a parameter to the sort method so that
+ * points in a point cloud can be sorted. Points are first compared by their
+ * first axis and consequently compared through their next axis if the previous
+ * are equal
+ * @param first : first element to compare
+ * @param second : second element to compare
+ * @return returns true if the first parameter is smaller than the second
+ * and false otherwise
+ */
+bool comparePoints(Eigen::Vector3d first, Eigen::Vector3d second) {
+  const double epsilon = 0.000001;
+
+  if (fabs(first[0] - second[0]) < epsilon) {
+    // Index 0 is the same so check next index
+    if (fabs(first[1] - second[1]) < epsilon) {
+      // Index 1 is the same so check the last index
+      if (fabs(first[2] - second[2]) < epsilon) {
+        // All elements are equal
+        return false;
+      } else {
+        // Points differ at index 2 so compare them normally
+        return first[2] < second[2];
+      }
+    } else {
+      // Points differ at index 1 so compare them normally
+      return first[1] < second[1];
+    }
+  } else {
+    // They are not equal so compare them normally
+    return first[0] < second[0];
+  }
+}
+
+
+namespace MPL {
+
+/**
+ * @brief In this test we verify that voxels outside of the map are identified
+ */
+TEST(MapUtilTest, TestIsOutside) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_free as the default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_free);
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  // Create a set of voxels indices that are outide the bounds of the map
+  vec_Vec3i outside_voxels;
+  outside_voxels.push_back(Vec3i(-1, 34, 2));
+  outside_voxels.push_back(Vec3i(0, 0, 20));
+  outside_voxels.push_back(Vec3i(5, 3, -1));
+  outside_voxels.push_back(Vec3i(6, -1, 4));
+  outside_voxels.push_back(Vec3i(298, 400, 7));
+
+  // Create a set of voxel indices that are inside the bounds of the map
+  vec_Vec3i inside_voxels;
+  inside_voxels.push_back(Vec3i(2, 5, 7));
+  inside_voxels.push_back(Vec3i(0, 0, 0));
+  inside_voxels.push_back(Vec3i(399, 399, 19));
+  inside_voxels.push_back(Vec3i(288, 179, 0));
+  inside_voxels.push_back(Vec3i(367, 118, 8));
+
+  // Check that the isOutside method correctly identifies inside and outside
+  // voxels
+  for (auto &vox : outside_voxels) {
+    EXPECT_TRUE(test_map.isOutside(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : inside_voxels) {
+    EXPECT_FALSE(test_map.isOutside(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+}
+
+/**
+ * @brief The isFree method returns a boolean value. In this test we initialize
+ * the map in the MapUtil object to have all of its voxels as free, then we set
+ * a few voxels to be non-free and finally verify that isFree can identify them
+ */
+TEST(MapUtilTest, TestIsFree) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_free as the default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_free);
+
+  vec_Vec3i non_free_voxels;
+  non_free_voxels.push_back(Vec3i(176, 91, 6));
+  non_free_voxels.push_back(Vec3i(102, 157, 12));
+  non_free_voxels.push_back(Vec3i(18, 261, 3));
+  non_free_voxels.push_back(Vec3i(253, 137, 4));
+  non_free_voxels.push_back(Vec3i(123, 158, 16));
+  for (auto &vox : non_free_voxels) {
+    int idx = vox(0) + dim(0) * vox(1) + dim(0) * dim(1) * vox(2);
+    base_map[idx] = planning_ros_msgs::VoxelMap::val_occ;
+  }
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  // Create a set of voxels indices that are outide the bounds of the map
+  vec_Vec3i outside_voxels;
+  outside_voxels.push_back(Vec3i(-1, 34, 2));
+  outside_voxels.push_back(Vec3i(0, 0, 20));
+  outside_voxels.push_back(Vec3i(5, 3, -1));
+  outside_voxels.push_back(Vec3i(6, -1, 4));
+  outside_voxels.push_back(Vec3i(298, 400, 7));
+
+  // Create a set of voxel indices that are free
+  vec_Vec3i free_voxels;
+  free_voxels.push_back(Vec3i(2, 5, 7));
+  free_voxels.push_back(Vec3i(0, 0, 0));
+  free_voxels.push_back(Vec3i(399, 399, 19));
+  free_voxels.push_back(Vec3i(288, 179, 0));
+  free_voxels.push_back(Vec3i(367, 118, 8));
+
+  // Check that the isFree method correctly identifies free and non-free voxels.
+  // It should return false for any out of bounds voxels
+  for (auto &vox : outside_voxels) {
+    EXPECT_FALSE(test_map.isFree(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : free_voxels) {
+    EXPECT_TRUE(test_map.isFree(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : non_free_voxels) {
+    EXPECT_FALSE(test_map.isFree(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+}
+
+/**
+ * @brief The isOccupied method returns a boolean value. In this test we
+ * initialize the map in the MapUtil object to have all of its voxels as
+ * occupied, then we set a few voxels to be non-occupied and finally verify that
+ * isOccupied can identify them
+ */
+TEST(MapUtilTest, TestIsOccupied) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_occ as the default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_occ);
+
+  vec_Vec3i non_occ_voxels;
+  non_occ_voxels.push_back(Vec3i(176, 91, 6));
+  non_occ_voxels.push_back(Vec3i(102, 157, 12));
+  non_occ_voxels.push_back(Vec3i(18, 261, 3));
+  non_occ_voxels.push_back(Vec3i(253, 137, 4));
+  non_occ_voxels.push_back(Vec3i(123, 158, 16));
+  for (auto &vox : non_occ_voxels) {
+    int idx = vox(0) + dim(0) * vox(1) + dim(0) * dim(1) * vox(2);
+    base_map[idx] = planning_ros_msgs::VoxelMap::val_free;
+  }
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  // Create a set of voxels indices that are outide the bounds of the map
+  vec_Vec3i outside_voxels;
+  outside_voxels.push_back(Vec3i(-1, 34, 2));
+  outside_voxels.push_back(Vec3i(0, 0, 20));
+  outside_voxels.push_back(Vec3i(5, 3, -1));
+  outside_voxels.push_back(Vec3i(6, -1, 4));
+  outside_voxels.push_back(Vec3i(298, 400, 7));
+
+  // Create a set of voxel indices that are occupied
+  vec_Vec3i occ_voxels;
+  occ_voxels.push_back(Vec3i(2, 5, 7));
+  occ_voxels.push_back(Vec3i(0, 0, 0));
+  occ_voxels.push_back(Vec3i(399, 399, 19));
+  occ_voxels.push_back(Vec3i(288, 179, 0));
+  occ_voxels.push_back(Vec3i(367, 118, 8));
+
+  // Check that the isOccupied method correctly identifies occupied and
+  // non-occupied voxels. It should return false for any out of bounds voxels
+  for (auto &vox : outside_voxels) {
+    EXPECT_FALSE(test_map.isOccupied(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : occ_voxels) {
+    EXPECT_TRUE(test_map.isOccupied(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : non_occ_voxels) {
+    EXPECT_FALSE(test_map.isOccupied(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+}
+
+/**
+ * @brief The isUnknown method returns a boolean value. In this test we
+ * initialize the map in the MapUtil object to have all of its voxels as
+ * unknown, then we set a few voxels to be non-unknown and finally verify that
+ * isUnknown can identify them.
+ */
+TEST(MapUtilTest, TestIsUnknown) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_unknown as the
+  // default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_unknown);
+
+  vec_Vec3i non_unknown_voxels;
+  non_unknown_voxels.push_back(Vec3i(176, 91, 6));
+  non_unknown_voxels.push_back(Vec3i(102, 157, 12));
+  non_unknown_voxels.push_back(Vec3i(18, 261, 3));
+  non_unknown_voxels.push_back(Vec3i(253, 137, 4));
+  non_unknown_voxels.push_back(Vec3i(123, 158, 16));
+  for (auto &vox : non_unknown_voxels) {
+    int idx = vox(0) + dim(0) * vox(1) + dim(0) * dim(1) * vox(2);
+    base_map[idx] = planning_ros_msgs::VoxelMap::val_occ;
+  }
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  // Create a set of voxels indices that are outide the bounds of the map
+  vec_Vec3i outside_voxels;
+  outside_voxels.push_back(Vec3i(-1, 34, 2));
+  outside_voxels.push_back(Vec3i(0, 0, 20));
+  outside_voxels.push_back(Vec3i(5, 3, -1));
+  outside_voxels.push_back(Vec3i(6, -1, 4));
+  outside_voxels.push_back(Vec3i(298, 400, 7));
+
+  // Create a set of voxel indices that are unknown
+  vec_Vec3i unknown_voxels;
+  unknown_voxels.push_back(Vec3i(2, 5, 7));
+  unknown_voxels.push_back(Vec3i(0, 0, 0));
+  unknown_voxels.push_back(Vec3i(399, 399, 19));
+  unknown_voxels.push_back(Vec3i(288, 179, 0));
+  unknown_voxels.push_back(Vec3i(367, 118, 8));
+
+  // Check that the isUnknown method correctly identifies unknown and
+  // non-unknown voxels. It should return false for any out of bounds voxels
+  for (auto &vox : outside_voxels) {
+    EXPECT_FALSE(test_map.isUnknown(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : unknown_voxels) {
+    EXPECT_TRUE(test_map.isUnknown(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+
+  for (auto &vox : non_unknown_voxels) {
+    EXPECT_FALSE(test_map.isUnknown(vox)) << "Voxel: ("
+      << vox(0) << ", " << vox(1) << ", " << vox(2) << ")\n";
+  }
+}
+
+/**
+ * @brief MapUtil considers voxels to be axis-aligned. In this test we make
+ * sure that the conversion from world coordinates to voxel indices and
+ * vice-versa are reciprocal and consistent. We check the use of the
+ * floatToInt and intToFloat functions.
+ */
+TEST(MapUtilTest, TestVoxelIndexing) {
+  // Create map_util object
+  VoxelMapUtil test_map;
+  // Dimensions are the amount of voxels in each axis
+  test_map.setMap(Vec3f(-100, -100, -5), Vec3i(400, 400, 20), {}, 0.5);
+
+  // Initialize set of points for converstion
+  vec_Vec3f point_cloud;      // Test point cloud
+  vec_Vec3f gt_point_cloud;   // Values that should be returned by intToFloat
+  vec_Vec3i voxel_indices;    // Values that should be returned by floatToInt
+
+  // Test most negative limit of the world
+  point_cloud.push_back(Vec3f(-100, -100, -5));
+  gt_point_cloud.push_back(Vec3f(-99.75, -99.75, -4.75));
+  voxel_indices.push_back(Vec3i(0, 0, 0));
+
+  // Test most positive limit of the world
+  point_cloud.push_back(Vec3f(100, 100, 5));
+  gt_point_cloud.push_back(Vec3f(100.25, 100.25, 5.25));
+  voxel_indices.push_back(Vec3i(400, 400, 20));
+
+  // Test outside the bounds of the world in the positive direction
+  point_cloud.push_back(Vec3f(105, 105, 10));
+  gt_point_cloud.push_back(Vec3f(105.25, 105.25, 10.25));
+  voxel_indices.push_back(Vec3i(410, 410, 30));
+
+  // Test outside the bounds of the world in the most negative direction
+  point_cloud.push_back(Vec3f(-105, -105, -10));
+  gt_point_cloud.push_back(Vec3f(-104.75, -104.75, -9.75));
+  voxel_indices.push_back(Vec3i(-10, -10, -10));
+
+  point_cloud.push_back(Vec3f(-100.1, -100.6, -4.9));
+  gt_point_cloud.push_back(Vec3f(-100.25, -100.75, -4.75));
+  voxel_indices.push_back(Vec3i(-1, -2, 0));
+
+  // Check points near the voxel boundaries to make sure that voxels are
+  // actually axis-aligned and not origin-centered
+  point_cloud.push_back(Vec3f(10.1, 10.1, 2));
+  gt_point_cloud.push_back(Vec3f(10.25, 10.25, 2.25));
+  voxel_indices.push_back(Vec3i(220, 220, 14));
+
+  point_cloud.push_back(Vec3f(10.9, 10.9, 2));
+  gt_point_cloud.push_back(Vec3f(10.75, 10.75, 2.25));
+  voxel_indices.push_back(Vec3i(221, 221, 14));
+
+  point_cloud.push_back(Vec3f(5.6, 5.6, 3));
+  gt_point_cloud.push_back(Vec3f(5.75, 5.75, 3.25));
+  voxel_indices.push_back(Vec3i(211, 211, 16));
+
+  point_cloud.push_back(Vec3f(5.4, 5.4, 3));
+  gt_point_cloud.push_back(Vec3f(5.25, 5.25, 3.25));
+  voxel_indices.push_back(Vec3i(210, 210, 16));
+
+  for (int i = 0; i < point_cloud.size(); i++) {
+    auto &point = point_cloud[i];
+    auto &gt_point = gt_point_cloud[i];
+    auto &voxel = voxel_indices[i];
+    Vec3i ret_indices = test_map.floatToInt(point);
+    Vec3f ret_point = test_map.intToFloat(ret_indices);
+
+    // Compare the returned indices to the actual voxel indices
+    for (int n = 0; n < 3; n++) {
+      EXPECT_EQ(voxel(n), ret_indices(n)) << "Point idx: " << i
+        << "  Voxel: (" << voxel(0) << ", " << voxel(1) << ", "
+        << voxel(2) << ")" << std::endl;
+    }
+
+    // Compare the original point to the returned point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(gt_point(n), ret_point(n)) << "Point idx: " << i
+        << "  Point: (" << point(0) << ", " << point(1) << ", "
+        << point(2) << ")" << std::endl;
+    }
+  }
+}
+
+/**
+ * @brief The getCloud method will return a vector of points (centered at the
+ * origin of voxels) corresponding to occupied voxels. In this test we initalize
+ * a map to have non-occupied voxels, then we set a particular set of voxels as
+ * occupied and verify that the corresponding point cloud is returned
+ */
+TEST(MapUtilTest, TestGetCloud) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_free as the default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_free);
+
+  vec_Vec3i occ_voxels;
+  vec_Vec3f occ_cloud;
+  occ_voxels.push_back(Vec3i(18, 261, 3));
+  occ_cloud.push_back(Vec3f(-90.75, 30.75, -3.25));
+
+  occ_voxels.push_back(Vec3i(102, 157, 12));
+  occ_cloud.push_back(Vec3f(-48.75, -21.25, 1.25));
+
+  occ_voxels.push_back(Vec3i(123, 158, 16));
+  occ_cloud.push_back(Vec3f(-38.25, -20.75, 3.25));
+
+  occ_voxels.push_back(Vec3i(176, 91, 6));
+  occ_cloud.push_back(Vec3f(-11.75, -54.25, -1.75));
+
+  occ_voxels.push_back(Vec3i(253, 137, 4));
+  occ_cloud.push_back(Vec3f(26.75, -31.25, -2.75));
+  for (auto &vox : occ_voxels) {
+    int idx = vox(0) + dim(0) * vox(1) + dim(0) * dim(1) * vox(2);
+    base_map[idx] = planning_ros_msgs::VoxelMap::val_occ;
+  }
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  vec_Vec3f ret_cloud = test_map.getCloud();
+  std::sort(ret_cloud.begin(), ret_cloud.end(), comparePoints);
+
+  ASSERT_EQ(occ_cloud.size(), ret_cloud.size());
+  // Iterate over every point
+  for (int i = 0; i < occ_cloud.size(); i++) {
+    // Iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(occ_cloud[i][n], ret_cloud[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
+    }
+  }
+}
+
+/**
+ * @brief The getFreeCloud method will return a vector of points (centered at
+ * the origin of voxels) corresponding to free voxels. In this test we initalize
+ * a map to have non-free voxels, then we set a particular set of voxels as
+ * free and verify that the corresponding point cloud is returned
+ */
+TEST(MapUtilTest, TestGetFreeCloud) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_occ as the default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_occ);
+
+  vec_Vec3i free_voxels;
+  vec_Vec3f free_cloud;
+  free_voxels.push_back(Vec3i(18, 261, 3));
+  free_cloud.push_back(Vec3f(-90.75, 30.75, -3.25));
+
+  free_voxels.push_back(Vec3i(102, 157, 12));
+  free_cloud.push_back(Vec3f(-48.75, -21.25, 1.25));
+
+  free_voxels.push_back(Vec3i(123, 158, 16));
+  free_cloud.push_back(Vec3f(-38.25, -20.75, 3.25));
+
+  free_voxels.push_back(Vec3i(176, 91, 6));
+  free_cloud.push_back(Vec3f(-11.75, -54.25, -1.75));
+
+  free_voxels.push_back(Vec3i(253, 137, 4));
+  free_cloud.push_back(Vec3f(26.75, -31.25, -2.75));
+  for (auto &vox : free_voxels) {
+    int idx = vox(0) + dim(0) * vox(1) + dim(0) * dim(1) * vox(2);
+    base_map[idx] = planning_ros_msgs::VoxelMap::val_free;
+  }
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  vec_Vec3f ret_cloud = test_map.getFreeCloud();
+  std::sort(ret_cloud.begin(), ret_cloud.end(), comparePoints);
+
+  ASSERT_EQ(free_cloud.size(), ret_cloud.size());
+  // Iterate over every point
+  for (int i = 0; i < free_cloud.size(); i++) {
+    // Iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(free_cloud[i][n], ret_cloud[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
+    }
+  }
+}
+
+/**
+ * @brief The getUnknownCloud method will return a vector of points (centered at
+ * the origin of voxels) corresponding to unknown voxels. In this test we
+ * initalize a map to have non-unknown voxels, then we set a particular set of
+ * voxels as unknown and verify that the corresponding point cloud is returned
+ */
+TEST(MapUtilTest, TestGetUnkwownCloud) {
+  VoxelMapUtil test_map;  // This is the MapUtil object
+
+  Vec3f origin(-100, -100, -5);
+  Vec3i dim(400, 400, 20);    // Amount of voxels along each axis
+  double resolution = 0.5;
+
+  // Create a base map for the MapUtil object with val_free as the default value
+  std::vector<signed char> base_map(dim(0) * dim(1) * dim(2),
+                                    planning_ros_msgs::VoxelMap::val_free);
+
+  vec_Vec3i unknown_voxels;
+  vec_Vec3f unknown_cloud;
+  unknown_voxels.push_back(Vec3i(18, 261, 3));
+  unknown_cloud.push_back(Vec3f(-90.75, 30.75, -3.25));
+
+  unknown_voxels.push_back(Vec3i(102, 157, 12));
+  unknown_cloud.push_back(Vec3f(-48.75, -21.25, 1.25));
+
+  unknown_voxels.push_back(Vec3i(123, 158, 16));
+  unknown_cloud.push_back(Vec3f(-38.25, -20.75, 3.25));
+
+  unknown_voxels.push_back(Vec3i(176, 91, 6));
+  unknown_cloud.push_back(Vec3f(-11.75, -54.25, -1.75));
+
+  unknown_voxels.push_back(Vec3i(253, 137, 4));
+  unknown_cloud.push_back(Vec3f(26.75, -31.25, -2.75));
+  for (auto &vox : unknown_voxels) {
+    int idx = vox(0) + dim(0) * vox(1) + dim(0) * dim(1) * vox(2);
+    base_map[idx] = planning_ros_msgs::VoxelMap::val_unknown;
+  }
+
+  // Initialize the MapUtil object with the previously created map
+  test_map.setMap(origin, dim, base_map, resolution);
+
+  vec_Vec3f ret_cloud = test_map.getUnknownCloud();
+  std::sort(ret_cloud.begin(), ret_cloud.end(), comparePoints);
+
+  ASSERT_EQ(unknown_cloud.size(), ret_cloud.size());
+  // Iterate over every point
+  for (int i = 0; i < unknown_cloud.size(); i++) {
+    // Iterate over every index in each point
+    for (int n = 0; n < 3; n++) {
+      EXPECT_DOUBLE_EQ(unknown_cloud[i][n], ret_cloud[i][n])
+        << "IDX: " << i << ", Axis: " << n << std::endl;
+    }
+  }
+}
+
+}   // namespace MPL
+
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+


### PR DESCRIPTION
Converted some functions in the MPL::MapUtil class to inline and changed the x-y-z traversing order to be more cache friendly given the storage order of the map.

I added some unit tests to assure the same functionality and some benchmarks to show the performance improvement.

Lasty I changed the source file for the VoxelMapper unit tests to have a 2-space indentation instead of 4-space for consistency with the rest of the files in the repo.

Here is a screen shot showing that calling these functions is faster by defining them as inline functions.
![image](https://user-images.githubusercontent.com/33842080/179654708-79047b0a-1885-4212-b7c3-ea1f44ada55d.png)
