### PR TITLE
Fix CI for base and control Docker images

### DIFF
--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        if: github.repository == 'kumarrobotics/kr_autonomous_flight'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -32,6 +36,6 @@ jobs:
         with:
           context: .
           file: ./autonomy_core/base/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' }}
           tags: kumarrobotics/autonomy:base

--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -1,4 +1,4 @@
-name: docker-build-base #Draft2
+name: docker-build-base
 
 on:
   push:
@@ -11,14 +11,11 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -30,11 +27,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push base image
+      - name: Build base image (push only on upstream)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./autonomy_core/base/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' }}
           tags: kumarrobotics/autonomy:base

--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -1,4 +1,4 @@
-name: docker-build-base
+name: docker-build-base #Draft2
 
 on:
   push:

--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -4,7 +4,7 @@ name: docker-build-base
 on:
   push:
     paths:
-    - 'autonomy_core/base/**'
+      - 'autonomy_core/base/**'
     branches: [master]
   workflow_dispatch:
   schedule:
@@ -15,27 +15,31 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push base image
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
-          push: true
-          tags: kumarrobotics/autonomy:base
+          context: .
           file: ./autonomy_core/base/Dockerfile
           platforms: linux/amd64,linux/arm64
-      -
-        name: Image digest
+          push: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' }}
+          tags: kumarrobotics/autonomy:base
+
+      - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -1,6 +1,5 @@
 name: docker-build-base
 
-# Only build base when any of the files in the base directory are modified
 on:
   push:
     paths:
@@ -25,14 +24,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        if: github.repository == 'kumarrobotics/kr_autonomous_flight'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push base image
-        id: docker_build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -40,6 +38,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' }}
           tags: kumarrobotics/autonomy:base
-
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-build-control.yaml
+++ b/.github/workflows/docker-build-control.yaml
@@ -11,42 +11,41 @@ on:
   workflow_dispatch:
   push:
     paths:
-    - 'autonomy_core/control/**'
+      - 'autonomy_core/control/**'
     branches: [master]
   # DO NOT add a schedule. This build will be triggered by base schedule.
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
-      -
-        # This action is now required because we are building with context,
-        # required to clone a third party repo
-        name: Checkout
-        uses: actions/checkout@v2
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: github.repository == 'kumarrobotics/kr_autonomous_flight'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        if: github.repository == 'kumarrobotics/kr_autonomous_flight'
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: kumarrobotics/autonomy:control
           file: ./autonomy_core/control/Dockerfile
-          platforms: linux/amd64,linux/arm64
-      -
-        name: Image digest
+          platforms: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ github.repository == 'kumarrobotics/kr_autonomous_flight' }}
+          tags: kumarrobotics/autonomy:control
+
+      - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/autonomy_core/control/Dockerfile
+++ b/autonomy_core/control/Dockerfile
@@ -1,10 +1,21 @@
 FROM kumarrobotics/autonomy:base
 
+# Fix ROS apt repo key (prevents EXPKEYSIG / 404 failures)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl gnupg2 ca-certificates lsb-release \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc \
+    | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" \
+    > /etc/apt/sources.list.d/ros1-latest.list
+
 RUN apt-get update \
     && apt-get install -y \
     ros-noetic-mavros \
     ros-noetic-mavros-msgs \
-    ros-noetic-mavros-extras
+    ros-noetic-mavros-extras \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /root/control_ws/src
 WORKDIR /root/control_ws
@@ -15,4 +26,3 @@ RUN catkin build -j2 --no-status -DCMAKE_BUILD_TYPE=Release
 
 COPY autonomy_core/control/docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-


### PR DESCRIPTION
## Summary

This PR restores a working CI signal for the Docker-based workflows in `kr_autonomous_flight`, starting with the base image and extending to the control image which depends on it.

The primary goal was not to modernize the entire pipeline, but to debug and fix failure modes caused by repository age, outdated GitHub Actions, and infrastructure assumptions that no longer hold.

## Changes

### docker-build-base
- Updated GitHub Actions to supported versions
- Removed assumptions about DockerHub credentials being present for CI runs
- Ensured the workflow can build successfully without pushing images
- Restored runner compatibility so jobs no longer hang waiting for runners

### docker-build-control
- Fixed build failures caused by outdated ROS package metadata and expired signing keys
- Updated build steps to reliably install dependencies again
- Verified the image builds correctly once the base image succeeds

## Debugging Process

- Identified CI failures caused by jobs hanging indefinitely due to outdated runner/action usage
- Isolated the base image as the root dependency blocking downstream builds
- Iteratively fixed CI configuration first, then addressed real Docker build failures
- Validated fixes by manually triggering workflows and reviewing logs

## Notes

This was one of my first experiences debugging a CI system of this size. I focused on restoring correctness and clarity while keeping changes minimal and well-scoped.
