### PR TITLE
ci: fix CI by updating runners and action versions

### DIFF
--- a/.github/workflows/cpplint-reviewdog.yaml
+++ b/.github/workflows/cpplint-reviewdog.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: reviewdog/action-cpplint@master
         with:
-          github_token: ${{ secrets.KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           flags: --exclude=autonomy_core/map_plan/jps3d/include/jps/graph_search.h --exclude autonomy_core/map_plan/jps3d/src/graph_search.cpp --exclude autonomy_core/state_machine/action_trackers/src/take_off_tracker.cpp --exclude autonomy_core/map_plan/mpl/include/mpl_basis/lambda.h --exclude autonomy_core/map_plan/mpl/include/mpl_planner/env_base.h --exclude autonomy_core/map_plan/mpl/src/env_base.cpp --exclude autonomy_core/map_plan/mpl/src/env_map.cpp
           filter: "-whitespace/comments,-whitespace/indent,-build/include_order,-whitespace/ending_newline,-runtime/references"

--- a/.github/workflows/cpplint-reviewdog.yaml
+++ b/.github/workflows/cpplint-reviewdog.yaml
@@ -5,7 +5,7 @@ jobs:
   cpplint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-cpplint@master
         with:
           github_token: ${{ secrets.KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG }}

--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -12,25 +12,26 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: kumarrobotics/autonomy:base

--- a/.github/workflows/docker-build-client.yaml
+++ b/.github/workflows/docker-build-client.yaml
@@ -17,30 +17,31 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         # This action is now required because we are building with context,
         # required to clone a third party repo
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-build-control.yaml
+++ b/.github/workflows/docker-build-control.yaml
@@ -17,30 +17,31 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         # This action is now required because we are building with context,
         # required to clone a third party repo
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-build-estimation.yaml
+++ b/.github/workflows/docker-build-estimation.yaml
@@ -17,25 +17,26 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: kumarrobotics/autonomy:estimation

--- a/.github/workflows/docker-build-map-plan.yaml
+++ b/.github/workflows/docker-build-map-plan.yaml
@@ -17,30 +17,31 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         # This action is now required because we are building with context,
         # required to clone a third party repo
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-build-sim.yaml
+++ b/.github/workflows/docker-build-sim.yaml
@@ -17,30 +17,31 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         # This action is now required because we are building with context,
         # required to clone a third party repo
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/docker-build-state-machine.yaml
+++ b/.github/workflows/docker-build-state-machine.yaml
@@ -17,30 +17,31 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
 
     steps:
       -
         # This action is now required because we are building with context,
         # required to clone a third party repo
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/pylint-reviewdog.yaml
+++ b/.github/workflows/pylint-reviewdog.yaml
@@ -9,7 +9,7 @@ jobs:
    - uses: actions/checkout@v4
    - uses: dciborow/action-pylint@0.0.4
      with:
-       github_token: ${{ secrets.KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG }}
+       github_token: ${{ secrets.GITHUB_TOKEN }}
        reporter: github-pr-check
        level: error
        pylint_rc: '.pylintrc-reviewdog'

--- a/.github/workflows/pylint-reviewdog.yaml
+++ b/.github/workflows/pylint-reviewdog.yaml
@@ -6,7 +6,7 @@ jobs:
   name: runner / pylint
   runs-on: ubuntu-latest
   steps:
-   - uses: actions/checkout@v2
+   - uses: actions/checkout@v4
    - uses: dciborow/action-pylint@0.0.4
      with:
        github_token: ${{ secrets.KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG }}

--- a/.github/workflows/shellcheck-reviewdog.yaml
+++ b/.github/workflows/shellcheck-reviewdog.yaml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: reviewdog/action-shellcheck@master
       with:
-        github_token: ${{ secrets.KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         reporter: github-pr-check
         exclude: |
           ./.git/*

--- a/.github/workflows/shellcheck-reviewdog.yaml
+++ b/.github/workflows/shellcheck-reviewdog.yaml
@@ -5,7 +5,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: reviewdog/action-shellcheck@master
       with:
         github_token: ${{ secrets.KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG }}


### PR DESCRIPTION
CI was broken. All docker builds sat in queue for 24h then got cancelled because `ubuntu-20.04` runners don't exist anymore. Linting checks were also failing on an expired custom GitHub token.

**Changes:**
- Runners: `ubuntu-20.04` → `ubuntu-24.04`
- All GitHub Actions bumped to current versions (docker actions v1/v2 → v3/v6, checkout → v4)
- 6h timeout added so builds fail fast instead of silently hanging
- Replaced expired `KR_AUTONOMOUS_FLIGHT_TOKEN_REVIEWDOG` with built-in `GITHUB_TOKEN` for reviewdog linters